### PR TITLE
build(deps): update action-diff-triggers dependency to v1.2.1

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -148,7 +148,7 @@ runs:
         done
 
     - id: triggers
-      uses: bcgov/action-diff-triggers@4abfcb211f5816d654d1c5a417e5431a2c4a5379 # v1.1.1
+      uses: bcgov/action-diff-triggers@a80e4b3cf77b7e05f84e74030e3bfa08b717a574 # v1.2.1
       with:
         triggers: ${{ inputs.triggers }}
         diff_branch: ${{ inputs.diff_branch || github.event.repository.default_branch}}

--- a/action.yml
+++ b/action.yml
@@ -153,7 +153,7 @@ runs:
         triggers: ${{ inputs.triggers }}
         diff_branch: ${{ inputs.diff_branch || github.event.repository.default_branch}}
     # Alway install don't consider triggers here.
-    - uses: bcgov/action-oc-runner@d2fc921aaa9d70684c186dbb7754e6985d44d86f # v1.4.1
+    - uses: bcgov/action-oc-runner@b1c55b8a8bd5f42b19f72e6ea7df6d6a6eda44a1 # v1.5.1
       with:
         oc_namespace: "${{ inputs.oc_namespace }}"
         oc_token: "${{ inputs.oc_token }}"


### PR DESCRIPTION
This PR updates the 'action-diff-triggers' dependency pin to 'v1.2.1' to support the standardized 'github_token' input boundary.