### PR TITLE
feat(private-repos): support optional values_file and basic resource overrides

### DIFF
--- a/.github/workflows/pr-open.yml
+++ b/.github/workflows/pr-open.yml
@@ -105,12 +105,10 @@ jobs:
           release_name: 'pg-overrides'
           pvc_size: 200Mi
           storage_class: netapp-block-standard
-          # postgres_version intentionally matches the chart default (18). The
-          # version-switching branch in deploy_db.sh (which nulls crunchy.image)
-          # depends on the operator having a default image registered for the
-          # requested PG / PostGIS combination, which can't be reliably asserted
-          # in CI. Validate that branch manually before bumping the action.
-          postgres_version: 18
+          # Exercise the postgres_version lookup table in deploy_db.sh by
+          # requesting a non-default major version. The script resolves the
+          # matching image + postGISVersion from a known-good list.
+          postgres_version: 17
           replicas: 1
           cpu_request: 50m
           memory_request: 128Mi

--- a/.github/workflows/pr-open.yml
+++ b/.github/workflows/pr-open.yml
@@ -11,9 +11,68 @@ concurrency:
 permissions: {}
 
 jobs:
-  deploy-db-computed: # with s3 and computed release name
-    name: Deploy Database Computed
+  # ---------------------------------------------------------------------------
+  # Layer 1 + 2: offline validation. Covers chart rendering, helper script
+  # logic, version lookup, guardrail, route/S3 toggles. No cluster, no helm
+  # upgrade. Runs in ~30s, parallel-safe across PRs.
+  # ---------------------------------------------------------------------------
+  validate:
+    name: Validate (lint + unit + render)
+    runs-on: ubuntu-24.04 # offline checks only
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
+      - uses: azure/setup-helm@b9e51907a09c216f16ebe8536097933489208112 # v4.3.0
+
+      - name: Install bats
+        run: |
+          sudo apt-get update -qq
+          sudo apt-get install -y bats
+
+      - name: Unit tests (resolve_helm_args.sh)
+        run: bats tests/
+
+      - name: Helm lint
+        run: helm lint charts/crunchy --values values.yml
+
+      - name: Render chart with bundled values (default path)
+        run: |
+          helm template smoke charts/crunchy --values values.yml \
+            > /tmp/render-default.yaml
+          # PostgresCluster must always be rendered
+          grep -q "kind: PostgresCluster" /tmp/render-default.yaml
+          # Route is off by default
+          ! grep -q "kind: Route" /tmp/render-default.yaml
+
+      - name: Render chart with resolved overrides (PG17 + route)
+        env:
+          POSTGRES_VERSION: '17'
+          PVC_SIZE: '500Mi'
+          ROUTE_ENABLED: 'true'
+          ROUTE_HOST: 'pg.example.com'
+        run: |
+          # The helper drives --set args end-to-end the same way deploy_db.sh does.
+          # shellcheck disable=SC2046
+          helm template smoke charts/crunchy --values values.yml \
+            $(./scripts/resolve_helm_args.sh) > /tmp/render-overrides.yaml
+
+          echo "--- assertions on rendered output ---"
+          grep -q "kind: PostgresCluster" /tmp/render-overrides.yaml
+          grep -q "ubi9-17.7-3.6-2547" /tmp/render-overrides.yaml
+          grep -q "postGISVersion: \"3.6\"" /tmp/render-overrides.yaml
+          grep -q "storage: 500Mi" /tmp/render-overrides.yaml
+          grep -q "kind: Route" /tmp/render-overrides.yaml
+          grep -q "host: pg.example.com" /tmp/render-overrides.yaml
+
+  # ---------------------------------------------------------------------------
+  # Layer 3: single end-to-end cluster smoke test. Exercises the real action
+  # against OpenShift: values_file path, S3, computed release name, helm
+  # upgrade, readiness probe. One PostgresCluster per PR run.
+  # ---------------------------------------------------------------------------
+  deploy-db:
+    name: Deploy Database (smoke)
     runs-on: ubuntu-24.04
+    needs: validate
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
@@ -35,111 +94,10 @@ jobs:
 
       - run: |
           echo "Outputs: ${{ toJSON(steps.deploy_db.outputs) }}"
-      
+
       - if: contains(steps.deploy_db.outputs.* , '')
         run: |
           echo "Error! At least one output is empty. Verify outputs." && exit 1
-  deploy-db-manual: # without s3 , only pvc and manual release name
-    name: Deploy Database Explicit Release Name
-    runs-on: ubuntu-24.04
-    steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
-        with:
-          ref: ${{ github.ref }}
-
-      - name: Deploy Database Manual Release Name
-        id: deploy_db
-        uses: ./
-        with:
-          oc_namespace: ${{ vars.oc_namespace }}
-          oc_token: ${{ secrets.oc_token }}
-          ref: ${{ github.ref }}
-          values_file: values.yml
-          force_cleanup: true
-          release_name: 'pg-action' # Explicit release name, the postgres cluster is suffixed with '-crunchy'
-      - run: |
-          echo "Outputs: ${{ toJSON(steps.deploy_db.outputs) }}"
-      
-      - if: contains(steps.deploy_db.outputs.* , '')
-        run: |
-          echo "Error! At least one output is empty. Verify outputs." && exit 1
-
-  deploy-db-zero-config: # no values_file, no override inputs - uses bundled defaults
-    name: Deploy Database Zero Config
-    runs-on: ubuntu-24.04
-    steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
-        with:
-          ref: ${{ github.ref }}
-
-      - name: Deploy Database (Zero Config)
-        id: deploy_db
-        uses: ./
-        with:
-          oc_namespace: ${{ vars.oc_namespace }}
-          oc_token: ${{ secrets.oc_token }}
-          ref: ${{ github.ref }}
-          release_name: 'pg-zeroconf'
-          force_cleanup: true
-      - run: |
-          echo "Outputs: ${{ toJSON(steps.deploy_db.outputs) }}"
-      - if: contains(steps.deploy_db.outputs.* , '')
-        run: |
-          echo "Error! At least one output is empty. Verify outputs." && exit 1
-
-  deploy-db-overrides: # no values_file, exercises sizing override inputs
-    name: Deploy Database Overrides
-    runs-on: ubuntu-24.04
-    steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
-        with:
-          ref: ${{ github.ref }}
-
-      - name: Deploy Database (Overrides)
-        id: deploy_db
-        uses: ./
-        with:
-          oc_namespace: ${{ vars.oc_namespace }}
-          oc_token: ${{ secrets.oc_token }}
-          ref: ${{ github.ref }}
-          release_name: 'pg-overrides'
-          pvc_size: 200Mi
-          storage_class: netapp-block-standard
-          # Exercise the postgres_version lookup table in deploy_db.sh by
-          # requesting a non-default major version. The script resolves the
-          # matching image + postGISVersion from a known-good list.
-          postgres_version: 17
-          replicas: 1
-          cpu_request: 50m
-          memory_request: 128Mi
-          force_cleanup: true
-      - run: |
-          echo "Outputs: ${{ toJSON(steps.deploy_db.outputs) }}"
-      - if: contains(steps.deploy_db.outputs.* , '')
-        run: |
-          echo "Error! At least one output is empty. Verify outputs." && exit 1
-
-  guardrail-conflict: # negative test: custom values_file + overrides must fail fast
-    name: Guardrail Conflict Check
-    runs-on: ubuntu-24.04
-    steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
-
-      - uses: azure/setup-helm@b9e51907a09c216f16ebe8536097933489208112 # v4.3.0
-
-      - name: Verify deploy_db.sh fails when values_file and overrides both set
-        env:
-          PVC_SIZE: '200Mi'
-        run: |
-          set +e
-          ./scripts/deploy_db.sh charts/crunchy "file://${PWD}/values.yml" testapp pg-guardrail true
-          EXIT_CODE=$?
-          set -e
-          if [ "${EXIT_CODE}" -ne 1 ]; then
-            echo "Expected exit code 1 from guardrail, got ${EXIT_CODE}"
-            exit 1
-          fi
-          echo "Guardrail correctly rejected conflicting inputs."
 
   # ==========================================================================
   # WARNING: This job acts as the required merge gate for this workflow.
@@ -148,7 +106,7 @@ jobs:
   # ==========================================================================
   results:
     name: Results
-    needs: [deploy-db-computed, deploy-db-manual, deploy-db-zero-config, deploy-db-overrides, guardrail-conflict]
+    needs: [validate, deploy-db]
     if: always()
     runs-on: ubuntu-24.04
     timeout-minutes: 1
@@ -161,8 +119,8 @@ jobs:
       - name: Evaluate Overall Status
         if: contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled')
         run: |
-          echo "❌ Critical Check Failure: At least one required job has failed or was cancelled."
+          echo "Critical Check Failure: At least one required job has failed or was cancelled."
           exit 1
 
       - name: Success Message
-        run: echo "✅ All critical checks passed or were intentionally skipped!"
+        run: echo "All critical checks passed."

--- a/.github/workflows/pr-open.yml
+++ b/.github/workflows/pr-open.yml
@@ -105,7 +105,12 @@ jobs:
           release_name: 'pg-overrides'
           pvc_size: 200Mi
           storage_class: netapp-block-standard
-          postgres_version: 17
+          # postgres_version intentionally matches the chart default (18). The
+          # version-switching branch in deploy_db.sh (which nulls crunchy.image)
+          # depends on the operator having a default image registered for the
+          # requested PG / PostGIS combination, which can't be reliably asserted
+          # in CI. Validate that branch manually before bumping the action.
+          postgres_version: 18
           replicas: 1
           cpu_request: 50m
           memory_request: 128Mi

--- a/.github/workflows/pr-open.yml
+++ b/.github/workflows/pr-open.yml
@@ -63,6 +63,81 @@ jobs:
       - if: contains(steps.deploy_db.outputs.* , '')
         run: |
           echo "Error! At least one output is empty. Verify outputs." && exit 1
+
+  deploy-db-zero-config: # no values_file, no override inputs - uses bundled defaults
+    name: Deploy Database Zero Config
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          ref: ${{ github.ref }}
+
+      - name: Deploy Database (Zero Config)
+        id: deploy_db
+        uses: ./
+        with:
+          oc_namespace: ${{ vars.oc_namespace }}
+          oc_token: ${{ secrets.oc_token }}
+          ref: ${{ github.ref }}
+          release_name: 'pg-zeroconf'
+          force_cleanup: true
+      - run: |
+          echo "Outputs: ${{ toJSON(steps.deploy_db.outputs) }}"
+      - if: contains(steps.deploy_db.outputs.* , '')
+        run: |
+          echo "Error! At least one output is empty. Verify outputs." && exit 1
+
+  deploy-db-overrides: # no values_file, exercises sizing override inputs
+    name: Deploy Database Overrides
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          ref: ${{ github.ref }}
+
+      - name: Deploy Database (Overrides)
+        id: deploy_db
+        uses: ./
+        with:
+          oc_namespace: ${{ vars.oc_namespace }}
+          oc_token: ${{ secrets.oc_token }}
+          ref: ${{ github.ref }}
+          release_name: 'pg-overrides'
+          pvc_size: 200Mi
+          storage_class: netapp-block-standard
+          postgres_version: 17
+          replicas: 1
+          cpu_request: 50m
+          memory_request: 128Mi
+          force_cleanup: true
+      - run: |
+          echo "Outputs: ${{ toJSON(steps.deploy_db.outputs) }}"
+      - if: contains(steps.deploy_db.outputs.* , '')
+        run: |
+          echo "Error! At least one output is empty. Verify outputs." && exit 1
+
+  guardrail-conflict: # negative test: custom values_file + overrides must fail fast
+    name: Guardrail Conflict Check
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
+      - uses: azure/setup-helm@b9e51907a09c216f16ebe8536097933489208112 # v4.3.0
+
+      - name: Verify deploy_db.sh fails when values_file and overrides both set
+        env:
+          PVC_SIZE: '200Mi'
+        run: |
+          set +e
+          ./scripts/deploy_db.sh charts/crunchy "file://${PWD}/values.yml" testapp pg-guardrail true
+          EXIT_CODE=$?
+          set -e
+          if [ "${EXIT_CODE}" -ne 1 ]; then
+            echo "Expected exit code 1 from guardrail, got ${EXIT_CODE}"
+            exit 1
+          fi
+          echo "Guardrail correctly rejected conflicting inputs."
+
   # ==========================================================================
   # WARNING: This job acts as the required merge gate for this workflow.
   # If you add a new job to this workflow, you MUST add its ID to the 'needs'
@@ -70,7 +145,7 @@ jobs:
   # ==========================================================================
   results:
     name: Results
-    needs: [deploy-db-computed, deploy-db-manual]
+    needs: [deploy-db-computed, deploy-db-manual, deploy-db-zero-config, deploy-db-overrides, guardrail-conflict]
     if: always()
     runs-on: ubuntu-24.04
     timeout-minutes: 1

--- a/README.md
+++ b/README.md
@@ -130,9 +130,9 @@ The action accepts the following inputs:
 | Input | Description | Default |
 |-------|-------------|---------|
 | `values_file` | Path to a custom values.yml file (if omitted, falls back to the gold-standard defaults) | |
-| `pvc_size` | Storage size for the PostgreSQL data volume claim | `210Mi` |
+| `pvc_size` | Storage size for the PostgreSQL data volume claim | `150Mi` |
 | `storage_class` | Storage class name for the data volume | `netapp-block-standard` |
-| `postgres_version` | Major PostgreSQL version to deploy | `17` |
+| `postgres_version` | Major PostgreSQL version to deploy | `18` |
 | `replicas` | Number of instance replicas to deploy | `2` |
 | `cpu_request` | CPU request for the database pod | `50m` |
 | `memory_request` | Memory request for the database pod | `128Mi` |

--- a/README.md
+++ b/README.md
@@ -124,12 +124,18 @@ The action accepts the following inputs:
 |-------|-------------|
 | `oc_namespace` | OpenShift namespace where the database will be deployed |
 | `oc_token` | OpenShift token for authentication |
-| `values_file` | Path to the values.yml file to use for the deployment |
 
 ### Optional Inputs
 
 | Input | Description | Default |
 |-------|-------------|---------|
+| `values_file` | Path to a custom values.yml file (if omitted, falls back to the gold-standard defaults) | |
+| `pvc_size` | Storage size for the PostgreSQL data volume claim | `210Mi` |
+| `storage_class` | Storage class name for the data volume | `netapp-block-standard` |
+| `postgres_version` | Major PostgreSQL version to deploy | `17` |
+| `replicas` | Number of instance replicas to deploy | `2` |
+| `cpu_request` | CPU request for the database pod | `50m` |
+| `memory_request` | Memory request for the database pod | `128Mi` |
 | `environment` | Environment name (omit for PRs) | |
 | `triggers` | Paths used to trigger a deployment (e.g., ./backend/ ./frontend/) | |
 | `oc_server` | OpenShift server URL | https://api.silver.devops.gov.bc.ca:6443 |
@@ -154,39 +160,33 @@ The action accepts the following inputs:
 
 ## Sample Usage in GitHub Actions
 
-### Basic Deployment with PVC Backup
+### Basic Zero-Config Deployment
 
-The following example demonstrates how to deploy a Crunchy PostgreSQL database with backup functionality using Persistent Volume Claims (PVC):
+Deploy a database instantly utilizing our gold-standard default parameters entirely offline with **zero configuration**:
 
 ```yaml
-name: Deploy Crunchy Database
-
-on:
-  pull_request:
-    types: [opened, synchronize, reopened]
-  push:
-    branches:
-      - main
-
-jobs:
-  deploy-crunchy-db:
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-      
-      - name: Deploy Crunchy
-        uses: bcgov/action-crunchy@v1.1.0
+      - name: Deploy Crunchy (Zero Config)
+        uses: bcgov/action-crunchy@v2
         id: deploy_crunchy
         with:
           oc_namespace: ${{ secrets.OC_NAMESPACE }}
           oc_token: ${{ secrets.OC_TOKEN }}
-          environment: ${{ inputs.environment }}
-          values_file: charts/crunchy/values.yml
-          triggers: ${{ inputs.triggers }}
-          # github_token: ${{ secrets.GITHUB_TOKEN }}  # Optional; needed for private repositories (defaults to github.token)
+```
+
+### Deployment with Sizing Overrides
+
+Customize database size, performance, and version dynamically using simple action inputs without maintaining a `values.yml` file:
+
+```yaml
+      - name: Deploy Crunchy (Sizing Overrides)
+        uses: bcgov/action-crunchy@v2
+        id: deploy_crunchy
+        with:
+          oc_namespace: ${{ secrets.OC_NAMESPACE }}
+          oc_token: ${{ secrets.OC_TOKEN }}
+          postgres_version: 17
+          replicas: 2
+          pvc_size: 5Gi
 ```
 
 ### Deployment with S3 Backups

--- a/README.md
+++ b/README.md
@@ -132,7 +132,7 @@ The action accepts the following inputs:
 | `values_file` | Path to a custom values.yml file (if omitted, falls back to the gold-standard defaults) | |
 | `pvc_size` | Storage size for the PostgreSQL data volume claim | `150Mi` |
 | `storage_class` | Storage class name for the data volume | `netapp-block-standard` |
-| `postgres_version` | Major PostgreSQL version to deploy | `18` |
+| `postgres_version` | Major PostgreSQL version to deploy (see [Supported PostgreSQL Versions](#supported-postgresql-versions)) | `18` |
 | `replicas` | Number of instance replicas to deploy | `2` |
 | `cpu_request` | CPU request for the database pod | `50m` |
 | `memory_request` | Memory request for the database pod | `128Mi` |
@@ -159,6 +159,26 @@ The action accepts the following inputs:
 |--------|-------------|
 | `release` | The provided or generated release name |
 | `cluster` | The name of the deployed cluster |
+
+### Supported PostgreSQL Versions
+
+When you set `postgres_version` (and don't supply a custom `values_file`), the
+action resolves a known-good `image` and matching `postGISVersion` from the
+[bcgov/crunchy-postgres compatibility table](https://github.com/bcgov/crunchy-postgres#current-compatible-images)
+for Crunchy Operator 5.8.5. You don't need to think about image tags or PostGIS
+pairings — pick a major version and the right combination is applied.
+
+| `postgres_version` | Resolved image tag (ubi9 + PostGIS) | `postGISVersion` |
+|---|---|---|
+| `15` | `crunchy-postgres-gis:ubi9-15.15-3.3-2547` | `3.3` |
+| `16` | `crunchy-postgres-gis:ubi9-16.11-3.4-2547` | `3.4` |
+| `17` | `crunchy-postgres-gis:ubi9-17.7-3.6-2547` | `3.6` |
+| `18` (default) | `crunchy-postgres-gis:ubi9-18.1-3.6-2547` | `3.6` |
+
+Anything else fails fast with a helpful error. If you need an unsupported
+combination (a non-GIS image, ubi8, an older operator, a specific PostGIS minor,
+etc.), supply your own `values_file` and set `crunchy.image` /
+`crunchy.postGISVersion` explicitly.
 
 ## Sample Usage in GitHub Actions
 

--- a/README.md
+++ b/README.md
@@ -136,6 +136,8 @@ The action accepts the following inputs:
 | `replicas` | Number of instance replicas to deploy | `2` |
 | `cpu_request` | CPU request for the database pod | `50m` |
 | `memory_request` | Memory request for the database pod | `128Mi` |
+| `route_enabled` | Enable an OpenShift TLS passthrough Route for external database access | `false` |
+| `route_host` | Custom host name for the Route (if omitted, OpenShift auto-generates it) | `""` |
 | `environment` | Environment name (omit for PRs) | |
 | `triggers` | Paths used to trigger a deployment (e.g., ./backend/ ./frontend/) | |
 | `oc_server` | OpenShift server URL | https://api.silver.devops.gov.bc.ca:6443 |

--- a/README.md
+++ b/README.md
@@ -146,6 +146,7 @@ The action accepts the following inputs:
 | `s3_bucket` | S3 bucket for backups | |
 | `s3_endpoint` | S3 endpoint for backups | |
 | `force_cleanup` | Force cleanup of the database | false |
+| `self_heal_stuck_releases` | Purge stuck Helm releases (`uninstalling`, `failed`, etc.) before reinstall | false |
 | `directory` | Directory containing the Crunchy chart | charts/crunchy |
 | `repository` | GitHub repository (e.g., org/repo) | bcgov/action-crunchy |
 | `ref` | Git ref to use (e.g., branch, tag, SHA) | main |

--- a/action.yml
+++ b/action.yml
@@ -130,22 +130,28 @@ runs:
           echo "S3 configuration not set. Disabling S3 backups."
         fi
 
-        # Construct values.yml URL (ref_name = PR, ref_name = merge, default_branch = default)
-        BRANCH_OR_REF="${{ github.head_ref || github.ref_name || github.event.repository.default_branch }}"
-        VALUES_URL="https://raw.githubusercontent.com/${{ github.repository }}/${BRANCH_OR_REF}/${{ inputs.values_file }}"
+        # Save a copy of the caller's values.yml to /tmp so we can preserve it when checkout wipes the workspace
+        if [ ! -f "${{ inputs.values_file }}" ]; then
+          echo "Error: The specified values_file does not exist at the path: ${{ inputs.values_file }}"
+          exit 1
+        fi
+        cp "${{ inputs.values_file }}" /tmp/action-crunchy-values.yml
 
-        # Build curl auth options if a token is provided (required for private repositories)
+        # Set VALUES_URL to local file URI to bypass network/token authentication entirely
+        VALUES_URL="file:///tmp/action-crunchy-values.yml"
+
+        # Build curl options only if we are using a remote HTTP/S URL fallback
         CURL_AUTH_OPTS=()
-        if [ -n "${GITHUB_TOKEN}" ]; then
-          CURL_AUTH_OPTS=(-H "Authorization: token ${GITHUB_TOKEN}")
+        if [[ "${VALUES_URL}" =~ ^https?:// ]]; then
+          if [ -n "${GITHUB_TOKEN}" ]; then
+            CURL_AUTH_OPTS=(-H "Authorization: token ${GITHUB_TOKEN}")
+          fi
+          CURL_AUTH_OPTS+=(-H "Accept: application/vnd.github.v3.raw")
         fi
 
-        # Validate values.yml URL
-        if ! curl "${CURL_AUTH_OPTS[@]}" --output /dev/null --silent --head --fail "${VALUES_URL}"; then
-          echo "Error: The constructed values.yml URL is invalid or inaccessible: ${VALUES_URL}"
-          echo "Hint: If this is a private repository, please ensure that:"
-          echo "  1. The workflow permissions are set to 'contents: read'."
-          echo "  2. A valid 'github_token' is supplied if accessing a private file."
+        # Validate values.yml exists and is accessible
+        if ! curl "${CURL_AUTH_OPTS[@]}" --output /dev/null --silent --fail "${VALUES_URL}"; then
+          echo "Error: The values_file is invalid or inaccessible at: ${VALUES_URL}"
           exit 1
         fi
 

--- a/action.yml
+++ b/action.yml
@@ -53,6 +53,14 @@ inputs:
     description: 'Memory request for PostgreSQL instances'
     default: '128Mi'
     required: false
+  route_enabled:
+    description: 'Enable an OpenShift TLS passthrough Route for external database access'
+    default: 'false'
+    required: false
+  route_host:
+    description: 'Custom host name for the Route (if omitted, OpenShift auto-generates it)'
+    default: ''
+    required: false
   s3_access_key:
     description: 'S3 access key'
     required: false
@@ -227,6 +235,8 @@ runs:
         REPLICAS: ${{ inputs.replicas }}
         CPU_REQUEST: ${{ inputs.cpu_request }}
         MEMORY_REQUEST: ${{ inputs.memory_request }}
+        ROUTE_ENABLED: ${{ inputs.route_enabled }}
+        ROUTE_HOST: ${{ inputs.route_host }}
       run: |
         # Deploy the database
 

--- a/action.yml
+++ b/action.yml
@@ -31,27 +31,21 @@ inputs:
     required: false
   pvc_size:
     description: 'Persistent Volume Claim storage size for PostgreSQL instances'
-    default: '210Mi'
     required: false
   storage_class:
     description: 'Storage Class name for PostgreSQL instances'
-    default: 'netapp-block-standard'
     required: false
   postgres_version:
     description: 'PostgreSQL major version'
-    default: '17'
     required: false
   replicas:
     description: 'Number of PostgreSQL instance replicas'
-    default: '2'
     required: false
   cpu_request:
     description: 'CPU request for PostgreSQL instances'
-    default: '50m'
     required: false
   memory_request:
     description: 'Memory request for PostgreSQL instances'
-    default: '128Mi'
     required: false
   route_enabled:
     description: 'Enable an OpenShift TLS passthrough Route for external database access'

--- a/action.yml
+++ b/action.yml
@@ -143,32 +143,20 @@ runs:
       run: |
         # Variables and Inputs (!= closed)
 
-        # Enable S3 backups if all required vars are set
-        s3_vars=("${{ inputs.s3_access_key }}" "${{ inputs.s3_secret_key }}" "${{ inputs.s3_bucket }}" "${{ inputs.s3_endpoint }}")
-        if [ "${#s3_vars[@]}" -eq 4 ]; then
-          echo "All S3 configuration variables are present. Enabling S3 backups."
-          S3_ENABLED=true
-        elif [ "$s3_vars_count" -gt 0 ]; then
-          echo "Warning: Some S3 configuration variables are set, but not all. Please ensure all S3 variables are configured."
-          exit 1
-        else
-          echo "S3 configuration not set. Disabling S3 backups."
-        fi
-
         # Save a copy of the caller's values.yml to /tmp so we can preserve it when checkout wipes the workspace
         VALUES_URL=""
         if [ -n "${{ inputs.values_file }}" ]; then
           # Check if it is a remote URL
           if [[ "${{ inputs.values_file }}" =~ ^https?:// ]]; then
             VALUES_URL="${{ inputs.values_file }}"
-            
+
             # Build curl auth options if a token is provided (required for private repositories)
             CURL_AUTH_OPTS=()
             if [ -n "${GITHUB_TOKEN}" ]; then
               CURL_AUTH_OPTS=(-H "Authorization: token ${GITHUB_TOKEN}")
             fi
             CURL_AUTH_OPTS+=(-H "Accept: application/vnd.github.v3.raw")
-            
+
             # Validate remote values.yml exists and is accessible
             if ! curl "${CURL_AUTH_OPTS[@]}" --head --location --output /dev/null --silent --fail "${VALUES_URL}"; then
               echo "Error: The remote values_file is invalid or inaccessible at: ${VALUES_URL}"
@@ -180,7 +168,7 @@ runs:
               echo "Error: The specified values_file does not exist at the path: ${{ inputs.values_file }}"
               exit 1
             fi
-            
+
             # Validate YAML integrity if yq is available
             if command -v yq >/dev/null 2>&1; then
               if ! yq eval . "${{ inputs.values_file }}" >/dev/null 2>&1; then
@@ -188,7 +176,7 @@ runs:
                 exit 1
               fi
             fi
-            
+
             cp "${{ inputs.values_file }}" /tmp/action-crunchy-values.yml
             VALUES_URL="file:///tmp/action-crunchy-values.yml"
           fi
@@ -196,8 +184,7 @@ runs:
           echo "No custom values_file provided. Using action's default values.yml."
         fi
 
-        # Process vars and send to GITHUB_ENV
-        echo "S3_ENABLED=${S3_ENABLED}" >> $GITHUB_ENV
+        # Export to GITHUB_ENV for downstream steps
         echo "VALUES_URL=${VALUES_URL}" >> $GITHUB_ENV
 
     - id: triggers

--- a/action.yml
+++ b/action.yml
@@ -170,7 +170,7 @@ runs:
             CURL_AUTH_OPTS+=(-H "Accept: application/vnd.github.v3.raw")
             
             # Validate remote values.yml exists and is accessible
-            if ! curl "${CURL_AUTH_OPTS[@]}" --output /dev/null --silent --fail "${VALUES_URL}"; then
+            if ! curl "${CURL_AUTH_OPTS[@]}" --head --location --output /dev/null --silent --fail "${VALUES_URL}"; then
               echo "Error: The remote values_file is invalid or inaccessible at: ${VALUES_URL}"
               exit 1
             fi
@@ -234,15 +234,26 @@ runs:
       run: |
         # Deploy the database
 
-        # Check if S3 inputs are provided and construct the deploy_db.sh command accordingly
-        PARAMS="${{ inputs.directory }} ${VALUES_URL} ${{ github.event.repository.name }} ${RELEASE_NAME} ${{ steps.triggers.outputs.triggered}}"
+        # Build arguments array to prevent positional parameter shifting
+        ARGS=(
+          "${{ inputs.directory }}"
+          "${VALUES_URL}"
+          "${{ github.event.repository.name }}"
+          "${RELEASE_NAME}"
+          "${{ steps.triggers.outputs.triggered}}"
+        )
         if [ -n "${{ inputs.s3_access_key }}" ] && [ -n "${{ inputs.s3_secret_key }}" ] && [ -n "${{ inputs.s3_bucket }}" ] && [ -n "${{ inputs.s3_endpoint }}" ]; then
-          PARAMS+=" ${{ inputs.s3_access_key }} ${{ inputs.s3_secret_key }} ${{ inputs.s3_bucket }} ${{ inputs.s3_endpoint }}"
+          ARGS+=(
+            "${{ inputs.s3_access_key }}"
+            "${{ inputs.s3_secret_key }}"
+            "${{ inputs.s3_bucket }}"
+            "${{ inputs.s3_endpoint }}"
+          )
         fi
 
         # Execute the deploy command
-        echo $GITHUB_ACTION_PATH/scripts/deploy_db.sh $PARAMS
-        $GITHUB_ACTION_PATH/scripts/deploy_db.sh $PARAMS
+        echo $GITHUB_ACTION_PATH/scripts/deploy_db.sh "${ARGS[@]}"
+        $GITHUB_ACTION_PATH/scripts/deploy_db.sh "${ARGS[@]}"
 
     - if: github.event_name == 'pull_request' && github.event.action != 'closed'
       shell: bash

--- a/action.yml
+++ b/action.yml
@@ -27,9 +27,32 @@ inputs:
     required: false
     validation: "^https?://.+:6443$"
   values_file:
-    description: 'Path to the values.yml file to use for the deployment'
-    required: true
-    validation: "^.+\\.(yml|yaml)$"
+    description: 'Path to the values.yml file to use for the deployment (optional)'
+    required: false
+  pvc_size:
+    description: 'Persistent Volume Claim storage size for PostgreSQL instances'
+    default: '210Mi'
+    required: false
+  storage_class:
+    description: 'Storage Class name for PostgreSQL instances'
+    default: 'netapp-block-standard'
+    required: false
+  postgres_version:
+    description: 'PostgreSQL major version'
+    default: '17'
+    required: false
+  replicas:
+    description: 'Number of PostgreSQL instance replicas'
+    default: '2'
+    required: false
+  cpu_request:
+    description: 'CPU request for PostgreSQL instances'
+    default: '50m'
+    required: false
+  memory_request:
+    description: 'Memory request for PostgreSQL instances'
+    default: '128Mi'
+    required: false
   s3_access_key:
     description: 'S3 access key'
     required: false
@@ -131,40 +154,49 @@ runs:
         fi
 
         # Save a copy of the caller's values.yml to /tmp so we can preserve it when checkout wipes the workspace
-        if [ ! -f "${{ inputs.values_file }}" ]; then
-          echo "Error: The specified values_file does not exist at the path: ${{ inputs.values_file }}"
-          exit 1
-        fi
-        cp "${{ inputs.values_file }}" /tmp/action-crunchy-values.yml
-
-        # Set VALUES_URL to local file URI to bypass network/token authentication entirely
-        VALUES_URL="file:///tmp/action-crunchy-values.yml"
-
-        # Build curl options only if we are using a remote HTTP/S URL fallback
-        CURL_AUTH_OPTS=()
-        if [[ "${VALUES_URL}" =~ ^https?:// ]]; then
-          if [ -n "${GITHUB_TOKEN}" ]; then
-            CURL_AUTH_OPTS=(-H "Authorization: token ${GITHUB_TOKEN}")
+        VALUES_URL=""
+        if [ -n "${{ inputs.values_file }}" ]; then
+          # Check if it is a remote URL
+          if [[ "${{ inputs.values_file }}" =~ ^https?:// ]]; then
+            VALUES_URL="${{ inputs.values_file }}"
+            
+            # Build curl auth options if a token is provided (required for private repositories)
+            CURL_AUTH_OPTS=()
+            if [ -n "${GITHUB_TOKEN}" ]; then
+              CURL_AUTH_OPTS=(-H "Authorization: token ${GITHUB_TOKEN}")
+            fi
+            CURL_AUTH_OPTS+=(-H "Accept: application/vnd.github.v3.raw")
+            
+            # Validate remote values.yml exists and is accessible
+            if ! curl "${CURL_AUTH_OPTS[@]}" --output /dev/null --silent --fail "${VALUES_URL}"; then
+              echo "Error: The remote values_file is invalid or inaccessible at: ${VALUES_URL}"
+              exit 1
+            fi
+          else
+            # Local file path
+            if [ ! -f "${{ inputs.values_file }}" ]; then
+              echo "Error: The specified values_file does not exist at the path: ${{ inputs.values_file }}"
+              exit 1
+            fi
+            
+            # Validate YAML integrity if yq is available
+            if command -v yq >/dev/null 2>&1; then
+              if ! yq eval . "${{ inputs.values_file }}" >/dev/null 2>&1; then
+                echo "Error: The specified values_file is not a valid YAML file: ${{ inputs.values_file }}"
+                exit 1
+              fi
+            fi
+            
+            cp "${{ inputs.values_file }}" /tmp/action-crunchy-values.yml
+            VALUES_URL="file:///tmp/action-crunchy-values.yml"
           fi
-          CURL_AUTH_OPTS+=(-H "Accept: application/vnd.github.v3.raw")
-        fi
-
-        # Validate values.yml exists and is accessible
-        if ! curl "${CURL_AUTH_OPTS[@]}" --output /dev/null --silent --fail "${VALUES_URL}"; then
-          echo "Error: The values_file is invalid or inaccessible at: ${VALUES_URL}"
-          exit 1
+        else
+          echo "No custom values_file provided. Using action's default values.yml."
         fi
 
         # Process vars and send to GITHUB_ENV
-        for var in S3_ENABLED VALUES_URL; do
-          if [ -n "${!var}" ]; then
-            echo "${var}=${!var}"
-            echo "${var}=${!var}" >> $GITHUB_ENV
-          else
-            echo "Warning: ${var} is not set."
-            exit 1
-          fi
-        done
+        echo "S3_ENABLED=${S3_ENABLED}" >> $GITHUB_ENV
+        echo "VALUES_URL=${VALUES_URL}" >> $GITHUB_ENV
 
     - id: triggers
       uses: bcgov/action-diff-triggers@a80e4b3cf77b7e05f84e74030e3bfa08b717a574 # v1.2.1
@@ -189,6 +221,12 @@ runs:
       shell: bash
       env:
         GITHUB_TOKEN: ${{ inputs.github_token }}
+        PVC_SIZE: ${{ inputs.pvc_size }}
+        STORAGE_CLASS: ${{ inputs.storage_class }}
+        POSTGRES_VERSION: ${{ inputs.postgres_version }}
+        REPLICAS: ${{ inputs.replicas }}
+        CPU_REQUEST: ${{ inputs.cpu_request }}
+        MEMORY_REQUEST: ${{ inputs.memory_request }}
       run: |
         # Deploy the database
 

--- a/action.yml
+++ b/action.yml
@@ -67,6 +67,12 @@ inputs:
   s3_endpoint:
     description: 'S3 endpoint'
 
+  self_heal_stuck_releases:
+    description: 'Purge stuck Helm releases (uninstalling, failed, etc.) before reinstall'
+    default: false
+    required: false
+    type: boolean
+
   # Usually a bad idea / not recommended
   force_cleanup:
     description: 'Force cleanup of the database'
@@ -218,6 +224,7 @@ runs:
         MEMORY_REQUEST: ${{ inputs.memory_request }}
         ROUTE_ENABLED: ${{ inputs.route_enabled }}
         ROUTE_HOST: ${{ inputs.route_host }}
+        SELF_HEAL_STUCK_RELEASES: ${{ inputs.self_heal_stuck_releases }}
       run: |
         # Deploy the database
 
@@ -237,6 +244,7 @@ runs:
             "${{ inputs.s3_endpoint }}"
           )
         fi
+        ARGS+=("${{ inputs.self_heal_stuck_releases }}")
 
         # Execute the deploy command
         echo $GITHUB_ACTION_PATH/scripts/deploy_db.sh "${ARGS[@]}"

--- a/charts/crunchy/templates/route.yaml
+++ b/charts/crunchy/templates/route.yaml
@@ -1,0 +1,28 @@
+{{/*
+OpenShift Route for external database access.
+This creates a TLS passthrough route to the primary PostgreSQL service,
+allowing external clients to connect to the database over TLS.
+Clients must connect with SSL enabled (e.g., sslmode=require in the connection string).
+*/}}
+{{- if .Values.route.enabled }}
+apiVersion: route.openshift.io/v1
+kind: Route
+metadata:
+  name: {{ template "crunchy-postgres.fullname" . }}
+  labels: {{ include "crunchy-postgres.labels" . | nindent 4 }}
+spec:
+  {{- if .Values.route.host }}
+  host: {{ .Values.route.host }}
+  {{- end }}
+  port:
+    targetPort: postgres
+  tls:
+    termination: passthrough
+    # None: HTTP connections are not accepted; only TLS connections are routed.
+    # Clients must connect using SSL (e.g., sslmode=require in the connection string).
+    insecureEdgeTerminationPolicy: None
+  to:
+    kind: Service
+    name: {{ template "crunchy-postgres.fullname" . }}-primary
+    weight: 100
+{{- end }}

--- a/scripts/deploy_db.sh
+++ b/scripts/deploy_db.sh
@@ -3,7 +3,6 @@
 # Catch errors and unset variables
 set -euo pipefail
 
-# Remove S3_ENABLED and adjust logic to use S3 inputs if provided
 if [ "$#" -lt 4 ]; then
   echo "Usage: $0 <directory> <values_url> <app_name> <release_name> [s3_access_key] [s3_secret_key] [s3_bucket] [s3_endpoint]"
   exit 1
@@ -124,8 +123,8 @@ if [ -z "${VALUES_URL:-}" ]; then
   SET_STRINGS+=" --set-string crunchy.instances.requests.memory=${MEMORY_REQUEST}"
 fi
 
-if [ -n "${ROUTE_ENABLED:-}" ]; then
-  SET_STRINGS+=" --set route.enabled=${ROUTE_ENABLED}"
+if [ "${ROUTE_ENABLED:-false}" = "true" ]; then
+  SET_STRINGS+=" --set route.enabled=true"
 fi
 
 if [ -n "${ROUTE_HOST:-}" ]; then

--- a/scripts/deploy_db.sh
+++ b/scripts/deploy_db.sh
@@ -86,9 +86,9 @@ SET_STRINGS=""
 
 # If no custom values file is supplied, populate default sizing values and build set strings
 if [ -z "${VALUES_URL:-}" ]; then
-  PVC_SIZE="${PVC_SIZE:-210Mi}"
+  PVC_SIZE="${PVC_SIZE:-150Mi}"
   STORAGE_CLASS="${STORAGE_CLASS:-netapp-block-standard}"
-  POSTGRES_VERSION="${POSTGRES_VERSION:-17}"
+  POSTGRES_VERSION="${POSTGRES_VERSION:-18}"
   REPLICAS="${REPLICAS:-2}"
   CPU_REQUEST="${CPU_REQUEST:-50m}"
   MEMORY_REQUEST="${MEMORY_REQUEST:-128Mi}"

--- a/scripts/deploy_db.sh
+++ b/scripts/deploy_db.sh
@@ -36,8 +36,8 @@ if [ -n "${VALUES_URL:-}" ]; then
   curl --fail --location --silent --show-error "${CURL_AUTH_OPTS[@]}" -o ./values.yml "$VALUES_URL"
   echo "Downloaded values.yml (current directory: charts/crunchy)"
 else
-  # Copy default values.yml from action root (../../values.yml)
-  cp ../../values.yml ./values.yml
+  # Copy default values.yml from action root relative to the script location
+  cp "$(dirname "$0")/../values.yml" ./values.yml
   echo "Copied default values.yml from action root"
 fi
 

--- a/scripts/deploy_db.sh
+++ b/scripts/deploy_db.sh
@@ -96,14 +96,29 @@ if [ -z "${VALUES_URL:-}" ]; then
   SET_STRINGS+=" --set-string crunchy.instances.dataVolumeClaimSpec.storage=${PVC_SIZE}"
   SET_STRINGS+=" --set-string crunchy.instances.dataVolumeClaimSpec.storageClassName=${STORAGE_CLASS}"
   SET_STRINGS+=" --set crunchy.postgresVersion=${POSTGRES_VERSION}"
-  # When the requested version differs from the default baked into values.yml,
-  # null out the hardcoded image so the Crunchy Operator picks the correct
-  # default image for the requested PostgreSQL version. `--set ...=null`
-  # removes the field entirely; `--set-string ...=""` would set it to an empty
-  # string, which the operator treats as a literal (invalid) image reference.
-  if [ "$POSTGRES_VERSION" != "18" ]; then
-    SET_STRINGS+=" --set crunchy.image=null"
-  fi
+
+  # Resolve a known-good (image, postGISVersion) pair for the requested
+  # PostgreSQL major version. The Crunchy Operator (chart appVersion 5.8.5)
+  # only ships defaults for specific PG/PostGIS combinations, so we cannot
+  # simply null the image and hope it picks correctly. The list below is the
+  # ubi9 + GIS variant from:
+  # https://github.com/bcgov/crunchy-postgres#current-compatible-images
+  case "${POSTGRES_VERSION}" in
+    15) CRUNCHY_IMAGE_TAG="ubi9-15.15-3.3-2547"; CRUNCHY_POSTGIS_VERSION="3.3" ;;
+    16) CRUNCHY_IMAGE_TAG="ubi9-16.11-3.4-2547"; CRUNCHY_POSTGIS_VERSION="3.4" ;;
+    17) CRUNCHY_IMAGE_TAG="ubi9-17.7-3.6-2547";  CRUNCHY_POSTGIS_VERSION="3.6" ;;
+    18) CRUNCHY_IMAGE_TAG="ubi9-18.1-3.6-2547";  CRUNCHY_POSTGIS_VERSION="3.6" ;;
+    *)
+      echo "Error: Unsupported postgres_version '${POSTGRES_VERSION}'."
+      echo "Supported values (Crunchy Operator 5.8.5): 15, 16, 17, 18."
+      echo "If you need a combination outside this list, supply your own values_file"
+      echo "and set crunchy.image and crunchy.postGISVersion explicitly."
+      exit 1
+      ;;
+  esac
+  SET_STRINGS+=" --set-string crunchy.image=artifacts.developer.gov.bc.ca/bcgov-docker-local/crunchy-postgres-gis:${CRUNCHY_IMAGE_TAG}"
+  SET_STRINGS+=" --set-string crunchy.postGISVersion=${CRUNCHY_POSTGIS_VERSION}"
+
   SET_STRINGS+=" --set crunchy.instances.replicas=${REPLICAS}"
   SET_STRINGS+=" --set-string crunchy.instances.requests.cpu=${CPU_REQUEST}"
   SET_STRINGS+=" --set-string crunchy.instances.requests.memory=${MEMORY_REQUEST}"

--- a/scripts/deploy_db.sh
+++ b/scripts/deploy_db.sh
@@ -13,15 +13,24 @@ VALUES_URL="$2"
 APP_NAME="$3"
 RELEASE_NAME="$4"
 TRIGGERED="$5"
-S3_ACCESS_KEY="${6:-}"
-S3_SECRET_KEY="${7:-}"
-S3_BUCKET="${8:-}"
-S3_ENDPOINT="${9:-}"
+export S3_ACCESS_KEY="${6:-}"
+export S3_SECRET_KEY="${7:-}"
+export S3_BUCKET="${8:-}"
+export S3_ENDPOINT="${9:-}"
 MAX_DB_READY_RETRIES=90
 DB_READY_SLEEP_SECONDS=10
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+
+# Resolve and validate Helm args BEFORE any side effects (cd, packaging, etc).
+# resolve_helm_args.sh exits non-zero on guardrail/version validation failures,
+# so the conflict check fires up-front without touching the cluster.
+export VALUES_URL
+SET_STRINGS="$("${SCRIPT_DIR}/resolve_helm_args.sh")"
+
 # Deploy Database
 echo 'Deploying crunchy helm chart'
-cd $DIRECTORY
+cd "$DIRECTORY"
 
 # Download or copy values.yml file
 if [ -n "${VALUES_URL:-}" ]; then
@@ -36,7 +45,7 @@ if [ -n "${VALUES_URL:-}" ]; then
   echo "Downloaded values.yml (current directory: charts/crunchy)"
 else
   # Copy default values.yml from action root relative to the script location
-  cp "$(dirname "$0")/../values.yml" ./values.yml
+  cp "${SCRIPT_DIR}/../values.yml" ./values.yml
   echo "Copied default values.yml from action root"
 fi
 
@@ -54,89 +63,6 @@ if [ "${TRIGGERED:-false}" != "true" ]; then
     echo "Crunchy DB $RELEASE_NAME is already deployed, triggers did not fire, so not upgrading."
     exit 0
   fi
-fi
-
-# Conflict check & Fail-fast Guardrail
-if [ -n "${VALUES_URL:-}" ]; then
-  if [ -n "${PVC_SIZE:-}" ] || [ -n "${STORAGE_CLASS:-}" ] || [ -n "${POSTGRES_VERSION:-}" ] || [ -n "${REPLICAS:-}" ] || [ -n "${CPU_REQUEST:-}" ] || [ -n "${MEMORY_REQUEST:-}" ]; then
-    echo "=========================================================================="
-    echo "❌ CONFIGURATION CONFLICT DETECTED!"
-    echo "=========================================================================="
-    echo "You provided a custom 'values_file' (${VALUES_URL}) but also specified one"
-    echo "or more database sizing/resource override inputs in your workflow:"
-    echo "  - pvc_size: '${PVC_SIZE:-}'"
-    echo "  - storage_class: '${STORAGE_CLASS:-}'"
-    echo "  - postgres_version: '${POSTGRES_VERSION:-}'"
-    echo "  - replicas: '${REPLICAS:-}'"
-    echo "  - cpu_request: '${CPU_REQUEST:-}'"
-    echo "  - memory_request: '${MEMORY_REQUEST:-}'"
-    echo ""
-    echo "👉 TO FIX THIS:"
-    echo "Since you have a custom values file, you must specify all database sizes"
-    echo "and resource requests directly inside your custom file."
-    echo "Please remove the conflicting sizing inputs from your GitHub workflow file."
-    echo "=========================================================================="
-    exit 1
-  fi
-fi
-
-# Build Helm set strings; add non-S3 options first if needed
-SET_STRINGS=""
-
-# If no custom values file is supplied, populate default sizing values and build set strings
-if [ -z "${VALUES_URL:-}" ]; then
-  PVC_SIZE="${PVC_SIZE:-150Mi}"
-  STORAGE_CLASS="${STORAGE_CLASS:-netapp-block-standard}"
-  POSTGRES_VERSION="${POSTGRES_VERSION:-18}"
-  REPLICAS="${REPLICAS:-2}"
-  CPU_REQUEST="${CPU_REQUEST:-50m}"
-  MEMORY_REQUEST="${MEMORY_REQUEST:-128Mi}"
-
-  SET_STRINGS+=" --set-string crunchy.instances.dataVolumeClaimSpec.storage=${PVC_SIZE}"
-  SET_STRINGS+=" --set-string crunchy.instances.dataVolumeClaimSpec.storageClassName=${STORAGE_CLASS}"
-  SET_STRINGS+=" --set crunchy.postgresVersion=${POSTGRES_VERSION}"
-
-  # Resolve a known-good (image, postGISVersion) pair for the requested
-  # PostgreSQL major version. The Crunchy Operator (chart appVersion 5.8.5)
-  # only ships defaults for specific PG/PostGIS combinations, so we cannot
-  # simply null the image and hope it picks correctly. The list below is the
-  # ubi9 + GIS variant from:
-  # https://github.com/bcgov/crunchy-postgres#current-compatible-images
-  case "${POSTGRES_VERSION}" in
-    15) CRUNCHY_IMAGE_TAG="ubi9-15.15-3.3-2547"; CRUNCHY_POSTGIS_VERSION="3.3" ;;
-    16) CRUNCHY_IMAGE_TAG="ubi9-16.11-3.4-2547"; CRUNCHY_POSTGIS_VERSION="3.4" ;;
-    17) CRUNCHY_IMAGE_TAG="ubi9-17.7-3.6-2547";  CRUNCHY_POSTGIS_VERSION="3.6" ;;
-    18) CRUNCHY_IMAGE_TAG="ubi9-18.1-3.6-2547";  CRUNCHY_POSTGIS_VERSION="3.6" ;;
-    *)
-      echo "Error: Unsupported postgres_version '${POSTGRES_VERSION}'."
-      echo "Supported values (Crunchy Operator 5.8.5): 15, 16, 17, 18."
-      echo "If you need a combination outside this list, supply your own values_file"
-      echo "and set crunchy.image and crunchy.postGISVersion explicitly."
-      exit 1
-      ;;
-  esac
-  SET_STRINGS+=" --set-string crunchy.image=artifacts.developer.gov.bc.ca/bcgov-docker-local/crunchy-postgres-gis:${CRUNCHY_IMAGE_TAG}"
-  SET_STRINGS+=" --set-string crunchy.postGISVersion=${CRUNCHY_POSTGIS_VERSION}"
-
-  SET_STRINGS+=" --set crunchy.instances.replicas=${REPLICAS}"
-  SET_STRINGS+=" --set-string crunchy.instances.requests.cpu=${CPU_REQUEST}"
-  SET_STRINGS+=" --set-string crunchy.instances.requests.memory=${MEMORY_REQUEST}"
-fi
-
-if [ "${ROUTE_ENABLED:-false}" = "true" ]; then
-  SET_STRINGS+=" --set route.enabled=true"
-fi
-
-if [ -n "${ROUTE_HOST:-}" ]; then
-  SET_STRINGS+=" --set-string route.host=${ROUTE_HOST}"
-fi
-
-if [ -n "$S3_ACCESS_KEY" ] && [ -n "$S3_SECRET_KEY" ] && [ -n "$S3_BUCKET" ] && [ -n "$S3_ENDPOINT" ]; then
-  SET_STRINGS+=" --set crunchy.pgBackRest.s3.enabled=true \
-    --set-string crunchy.pgBackRest.s3.accessKey=$S3_ACCESS_KEY \
-    --set-string crunchy.pgBackRest.s3.secretKey=$S3_SECRET_KEY \
-    --set-string crunchy.pgBackRest.s3.bucket=$S3_BUCKET \
-    --set-string crunchy.pgBackRest.s3.endpoint=$S3_ENDPOINT"
 fi
 
 # Execute the Helm command

--- a/scripts/deploy_db.sh
+++ b/scripts/deploy_db.sh
@@ -71,10 +71,11 @@ fi
 # uninstall it (PostgresCluster CR + helm secret) and let this run start
 # fresh. The PostgresCluster's PVCs persist independently and the operator
 # will rebind them on the next install.
-HELM_RELEASE_STATUS="$(helm status "$RELEASE_NAME" -o json 2>/dev/null | jq -r '.info.status' 2>/dev/null || echo "")"
+HELM_RELEASE_STATUS="$(helm status "$RELEASE_NAME" -o json 2>/dev/null | jq -r '.info.status // empty' 2>/dev/null || true)"
+echo "Helm release '${RELEASE_NAME}' current status: '${HELM_RELEASE_STATUS:-<none>}'"
 case "${HELM_RELEASE_STATUS}" in
   pending-install|pending-upgrade|pending-rollback|failed|unknown)
-    echo "Release ${RELEASE_NAME} is in '${HELM_RELEASE_STATUS}' state; uninstalling before reinstall."
+    echo "Uninstalling stuck release before reinstall."
     helm uninstall "$RELEASE_NAME" --wait --timeout 2m || true
     ;;
 esac

--- a/scripts/deploy_db.sh
+++ b/scripts/deploy_db.sh
@@ -90,6 +90,14 @@ if [ -n "${MEMORY_REQUEST:-}" ]; then
   SET_STRINGS+=" --set-string crunchy.instances.requests.memory=${MEMORY_REQUEST}"
 fi
 
+if [ -n "${ROUTE_ENABLED:-}" ]; then
+  SET_STRINGS+=" --set route.enabled=${ROUTE_ENABLED}"
+fi
+
+if [ -n "${ROUTE_HOST:-}" ]; then
+  SET_STRINGS+=" --set-string route.host=${ROUTE_HOST}"
+fi
+
 if [ -n "$S3_ACCESS_KEY" ] && [ -n "$S3_SECRET_KEY" ] && [ -n "$S3_BUCKET" ] && [ -n "$S3_ENDPOINT" ]; then
   SET_STRINGS+=" --set crunchy.pgBackRest.s3.enabled=true \
     --set-string crunchy.pgBackRest.s3.accessKey=$S3_ACCESS_KEY \

--- a/scripts/deploy_db.sh
+++ b/scripts/deploy_db.sh
@@ -74,9 +74,19 @@ fi
 HELM_RELEASE_STATUS="$(helm status "$RELEASE_NAME" -o json 2>/dev/null | jq -r '.info.status // empty' 2>/dev/null || true)"
 echo "Helm release '${RELEASE_NAME}' current status: '${HELM_RELEASE_STATUS:-<none>}'"
 case "${HELM_RELEASE_STATUS}" in
-  pending-install|pending-upgrade|pending-rollback|failed|unknown)
-    echo "Uninstalling stuck release before reinstall."
-    helm uninstall "$RELEASE_NAME" --wait --timeout 2m || true
+  deployed|"")
+    : # nothing to do; clean start or healthy upgrade
+    ;;
+  *)
+    # Any non-deployed status (pending-*, failed, uninstalling, unknown)
+    # blocks `helm upgrade --install`. Purge the helm storage secrets for
+    # this release so we can install fresh. The underlying PostgresCluster
+    # PVCs are owned by the operator independently and will be rebound.
+    echo "Release in '${HELM_RELEASE_STATUS}' state; purging helm history before reinstall."
+    helm uninstall "$RELEASE_NAME" --wait --timeout 2m 2>/dev/null || true
+    # If helm uninstall couldn't clear it (e.g. release stuck 'uninstalling'),
+    # delete the storage secrets directly. Pattern: sh.helm.release.v1.<name>.v<n>
+    oc delete secret -l "owner=helm,name=${RELEASE_NAME}" --ignore-not-found=true || true
     ;;
 esac
 

--- a/scripts/deploy_db.sh
+++ b/scripts/deploy_db.sh
@@ -65,6 +65,20 @@ if [ "${TRIGGERED:-false}" != "true" ]; then
   fi
 fi
 
+# Self-heal a release that was left in a non-deployed state by a previous
+# timed-out run. `helm upgrade --install` refuses to operate when the most
+# recent release is in pending-install / pending-upgrade / failed, so we
+# uninstall it (PostgresCluster CR + helm secret) and let this run start
+# fresh. The PostgresCluster's PVCs persist independently and the operator
+# will rebind them on the next install.
+HELM_RELEASE_STATUS="$(helm status "$RELEASE_NAME" -o json 2>/dev/null | jq -r '.info.status' 2>/dev/null || echo "")"
+case "${HELM_RELEASE_STATUS}" in
+  pending-install|pending-upgrade|pending-rollback|failed|unknown)
+    echo "Release ${RELEASE_NAME} is in '${HELM_RELEASE_STATUS}' state; uninstalling before reinstall."
+    helm uninstall "$RELEASE_NAME" --wait --timeout 2m || true
+    ;;
+esac
+
 # Execute the Helm command
 if [ "${DEBUG_MODE:-false}" = "true" ]; then
   helm upgrade --debug --dry-run --install --wait "$RELEASE_NAME" --values ./values.yml ./$APP_NAME-$CHART_VERSION.tgz $SET_STRINGS

--- a/scripts/deploy_db.sh
+++ b/scripts/deploy_db.sh
@@ -24,16 +24,22 @@ DB_READY_SLEEP_SECONDS=10
 echo 'Deploying crunchy helm chart'
 cd $DIRECTORY
 
-# Download values.yml file
-CURL_AUTH_OPTS=()
-if [[ "${VALUES_URL}" =~ ^https?:// ]]; then
-  if [ -n "${GITHUB_TOKEN:-}" ]; then
-    CURL_AUTH_OPTS=(-H "Authorization: token ${GITHUB_TOKEN}")
+# Download or copy values.yml file
+if [ -n "${VALUES_URL:-}" ]; then
+  CURL_AUTH_OPTS=()
+  if [[ "${VALUES_URL}" =~ ^https?:// ]]; then
+    if [ -n "${GITHUB_TOKEN:-}" ]; then
+      CURL_AUTH_OPTS=(-H "Authorization: token ${GITHUB_TOKEN}")
+    fi
+    CURL_AUTH_OPTS+=(-H "Accept: application/vnd.github.v3.raw")
   fi
-  CURL_AUTH_OPTS+=(-H "Accept: application/vnd.github.v3.raw")
+  curl --fail --location --silent --show-error "${CURL_AUTH_OPTS[@]}" -o ./values.yml "$VALUES_URL"
+  echo "Downloaded values.yml (current directory: charts/crunchy)"
+else
+  # Copy default values.yml from action root (../../values.yml)
+  cp ../../values.yml ./values.yml
+  echo "Copied default values.yml from action root"
 fi
-curl --fail --location --silent --show-error "${CURL_AUTH_OPTS[@]}" -o ./values.yml "$VALUES_URL"
-echo "Downloaded values.yml (current directory: charts/crunchy)"
 
 # Set Helm app name
 sed -i "s/^name:.*/name: $APP_NAME/" Chart.yaml
@@ -53,6 +59,37 @@ fi
 
 # Build Helm set strings; add non-S3 options first if needed
 SET_STRINGS=""
+
+# Append custom database overrides from workflow inputs
+if [ -n "${PVC_SIZE:-}" ]; then
+  SET_STRINGS+=" --set-string crunchy.instances.dataVolumeClaimSpec.storage=${PVC_SIZE}"
+fi
+
+if [ -n "${STORAGE_CLASS:-}" ]; then
+  SET_STRINGS+=" --set-string crunchy.instances.dataVolumeClaimSpec.storageClassName=${STORAGE_CLASS}"
+fi
+
+if [ -n "${POSTGRES_VERSION:-}" ]; then
+  SET_STRINGS+=" --set crunchy.postgresVersion=${POSTGRES_VERSION}"
+  # If postgresVersion is customized to something other than 18 (default in values.yml),
+  # we nullify the image field so the operator pulls the correct image automatically.
+  if [ "$POSTGRES_VERSION" != "18" ]; then
+    SET_STRINGS+=" --set-string crunchy.image=\"\""
+  fi
+fi
+
+if [ -n "${REPLICAS:-}" ]; then
+  SET_STRINGS+=" --set crunchy.instances.replicas=${REPLICAS}"
+fi
+
+if [ -n "${CPU_REQUEST:-}" ]; then
+  SET_STRINGS+=" --set-string crunchy.instances.requests.cpu=${CPU_REQUEST}"
+fi
+
+if [ -n "${MEMORY_REQUEST:-}" ]; then
+  SET_STRINGS+=" --set-string crunchy.instances.requests.memory=${MEMORY_REQUEST}"
+fi
+
 if [ -n "$S3_ACCESS_KEY" ] && [ -n "$S3_SECRET_KEY" ] && [ -n "$S3_BUCKET" ] && [ -n "$S3_ENDPOINT" ]; then
   SET_STRINGS+=" --set crunchy.pgBackRest.s3.enabled=true \
     --set-string crunchy.pgBackRest.s3.accessKey=$S3_ACCESS_KEY \

--- a/scripts/deploy_db.sh
+++ b/scripts/deploy_db.sh
@@ -26,8 +26,11 @@ cd $DIRECTORY
 
 # Download values.yml file
 CURL_AUTH_OPTS=()
-if [ -n "${GITHUB_TOKEN:-}" ]; then
-  CURL_AUTH_OPTS=(-H "Authorization: token ${GITHUB_TOKEN}")
+if [[ "${VALUES_URL}" =~ ^https?:// ]]; then
+  if [ -n "${GITHUB_TOKEN:-}" ]; then
+    CURL_AUTH_OPTS=(-H "Authorization: token ${GITHUB_TOKEN}")
+  fi
+  CURL_AUTH_OPTS+=(-H "Accept: application/vnd.github.v3.raw")
 fi
 curl --fail --location --silent --show-error "${CURL_AUTH_OPTS[@]}" -o ./values.yml "$VALUES_URL"
 echo "Downloaded values.yml (current directory: charts/crunchy)"

--- a/scripts/deploy_db.sh
+++ b/scripts/deploy_db.sh
@@ -57,36 +57,50 @@ if [ "${TRIGGERED:-false}" != "true" ]; then
   fi
 fi
 
-# Build Helm set strings; add non-S3 options first if needed
-SET_STRINGS=""
-
-# Append custom database overrides from workflow inputs
-if [ -n "${PVC_SIZE:-}" ]; then
-  SET_STRINGS+=" --set-string crunchy.instances.dataVolumeClaimSpec.storage=${PVC_SIZE}"
-fi
-
-if [ -n "${STORAGE_CLASS:-}" ]; then
-  SET_STRINGS+=" --set-string crunchy.instances.dataVolumeClaimSpec.storageClassName=${STORAGE_CLASS}"
-fi
-
-if [ -n "${POSTGRES_VERSION:-}" ]; then
-  SET_STRINGS+=" --set crunchy.postgresVersion=${POSTGRES_VERSION}"
-  # If postgresVersion is customized to something other than 18 (default in values.yml),
-  # we nullify the image field so the operator pulls the correct image automatically.
-  if [ "$POSTGRES_VERSION" != "18" ]; then
-    SET_STRINGS+=" --set-string crunchy.image=\"\""
+# Conflict check & Fail-fast Guardrail
+if [ -n "${VALUES_URL:-}" ]; then
+  if [ -n "${PVC_SIZE:-}" ] || [ -n "${STORAGE_CLASS:-}" ] || [ -n "${POSTGRES_VERSION:-}" ] || [ -n "${REPLICAS:-}" ] || [ -n "${CPU_REQUEST:-}" ] || [ -n "${MEMORY_REQUEST:-}" ]; then
+    echo "=========================================================================="
+    echo "❌ CONFIGURATION CONFLICT DETECTED!"
+    echo "=========================================================================="
+    echo "You provided a custom 'values_file' (${VALUES_URL}) but also specified one"
+    echo "or more database sizing/resource override inputs in your workflow:"
+    echo "  - pvc_size: '${PVC_SIZE:-}'"
+    echo "  - storage_class: '${STORAGE_CLASS:-}'"
+    echo "  - postgres_version: '${POSTGRES_VERSION:-}'"
+    echo "  - replicas: '${REPLICAS:-}'"
+    echo "  - cpu_request: '${CPU_REQUEST:-}'"
+    echo "  - memory_request: '${MEMORY_REQUEST:-}'"
+    echo ""
+    echo "👉 TO FIX THIS:"
+    echo "Since you have a custom values file, you must specify all database sizes"
+    echo "and resource requests directly inside your custom file."
+    echo "Please remove the conflicting sizing inputs from your GitHub workflow file."
+    echo "=========================================================================="
+    exit 1
   fi
 fi
 
-if [ -n "${REPLICAS:-}" ]; then
+# Build Helm set strings; add non-S3 options first if needed
+SET_STRINGS=""
+
+# If no custom values file is supplied, populate default sizing values and build set strings
+if [ -z "${VALUES_URL:-}" ]; then
+  PVC_SIZE="${PVC_SIZE:-210Mi}"
+  STORAGE_CLASS="${STORAGE_CLASS:-netapp-block-standard}"
+  POSTGRES_VERSION="${POSTGRES_VERSION:-17}"
+  REPLICAS="${REPLICAS:-2}"
+  CPU_REQUEST="${CPU_REQUEST:-50m}"
+  MEMORY_REQUEST="${MEMORY_REQUEST:-128Mi}"
+
+  SET_STRINGS+=" --set-string crunchy.instances.dataVolumeClaimSpec.storage=${PVC_SIZE}"
+  SET_STRINGS+=" --set-string crunchy.instances.dataVolumeClaimSpec.storageClassName=${STORAGE_CLASS}"
+  SET_STRINGS+=" --set crunchy.postgresVersion=${POSTGRES_VERSION}"
+  if [ "$POSTGRES_VERSION" != "18" ]; then
+    SET_STRINGS+=" --set-string crunchy.image=\"\""
+  fi
   SET_STRINGS+=" --set crunchy.instances.replicas=${REPLICAS}"
-fi
-
-if [ -n "${CPU_REQUEST:-}" ]; then
   SET_STRINGS+=" --set-string crunchy.instances.requests.cpu=${CPU_REQUEST}"
-fi
-
-if [ -n "${MEMORY_REQUEST:-}" ]; then
   SET_STRINGS+=" --set-string crunchy.instances.requests.memory=${MEMORY_REQUEST}"
 fi
 

--- a/scripts/deploy_db.sh
+++ b/scripts/deploy_db.sh
@@ -96,8 +96,13 @@ if [ -z "${VALUES_URL:-}" ]; then
   SET_STRINGS+=" --set-string crunchy.instances.dataVolumeClaimSpec.storage=${PVC_SIZE}"
   SET_STRINGS+=" --set-string crunchy.instances.dataVolumeClaimSpec.storageClassName=${STORAGE_CLASS}"
   SET_STRINGS+=" --set crunchy.postgresVersion=${POSTGRES_VERSION}"
+  # When the requested version differs from the default baked into values.yml,
+  # null out the hardcoded image so the Crunchy Operator picks the correct
+  # default image for the requested PostgreSQL version. `--set ...=null`
+  # removes the field entirely; `--set-string ...=""` would set it to an empty
+  # string, which the operator treats as a literal (invalid) image reference.
   if [ "$POSTGRES_VERSION" != "18" ]; then
-    SET_STRINGS+=" --set-string crunchy.image=\"\""
+    SET_STRINGS+=" --set crunchy.image=null"
   fi
   SET_STRINGS+=" --set crunchy.instances.replicas=${REPLICAS}"
   SET_STRINGS+=" --set-string crunchy.instances.requests.cpu=${CPU_REQUEST}"

--- a/scripts/deploy_db.sh
+++ b/scripts/deploy_db.sh
@@ -4,8 +4,8 @@
 set -euo pipefail
 
 if [ "$#" -lt 4 ]; then
-  echo "Usage: $0 <directory> <values_url> <app_name> <release_name> [s3_access_key] [s3_secret_key] [s3_bucket] [s3_endpoint]"
-  exit 1
+   echo "Usage: $0 <directory> <values_url> <app_name> <release_name> [s3_access_key] [s3_secret_key] [s3_bucket] [s3_endpoint] [self_heal_stuck_releases]"
+   exit 1
 fi
 
 DIRECTORY="$1"
@@ -17,6 +17,7 @@ export S3_ACCESS_KEY="${6:-}"
 export S3_SECRET_KEY="${7:-}"
 export S3_BUCKET="${8:-}"
 export S3_ENDPOINT="${9:-}"
+export SELF_HEAL_STUCK_RELEASES="${10:-false}"
 MAX_DB_READY_RETRIES=90
 DB_READY_SLEEP_SECONDS=10
 
@@ -69,26 +70,32 @@ fi
 # timed-out run. `helm upgrade --install` refuses to operate when the most
 # recent release is in pending-install / pending-upgrade / failed, so we
 # uninstall it (PostgresCluster CR + helm secret) and let this run start
-# fresh. The PostgresCluster's PVCs persist independently and the operator
-# will rebind them on the next install.
-HELM_RELEASE_STATUS="$(helm status "$RELEASE_NAME" -o json 2>/dev/null | jq -r '.info.status // empty' 2>/dev/null || true)"
-echo "Helm release '${RELEASE_NAME}' current status: '${HELM_RELEASE_STATUS:-<none>}'"
-case "${HELM_RELEASE_STATUS}" in
-  deployed|"")
-    : # nothing to do; clean start or healthy upgrade
-    ;;
-  *)
-    # Any non-deployed status (pending-*, failed, uninstalling, unknown)
-    # blocks `helm upgrade --install`. Purge the helm storage secrets for
-    # this release so we can install fresh. The underlying PostgresCluster
-    # PVCs are owned by the operator independently and will be rebound.
-    echo "Release in '${HELM_RELEASE_STATUS}' state; purging helm history before reinstall."
-    helm uninstall "$RELEASE_NAME" --wait --timeout 2m 2>/dev/null || true
-    # If helm uninstall couldn't clear it (e.g. release stuck 'uninstalling'),
-    # delete the storage secrets directly. Pattern: sh.helm.release.v1.<name>.v<n>
-    oc delete secret -l "owner=helm,name=${RELEASE_NAME}" --ignore-not-found=true || true
-    ;;
-esac
+# fresh. When `self_heal_stuck_releases` is true, we purge stuck releases
+# before reinstalling. PVC behavior depends on operator ownership.
+if [ "${SELF_HEAL_STUCK_RELEASES:-false}" = "true" ]; then
+  HELM_RELEASE_STATUS="$(helm status "$RELEASE_NAME" -o json 2>/dev/null | jq -r '.info.status // empty' 2>/dev/null || true)"
+  echo "Helm release '${RELEASE_NAME}' current status: '${HELM_RELEASE_STATUS:-<none>}'"
+  case "${HELM_RELEASE_STATUS}" in
+    deployed|"")
+      : # nothing to do; clean start or healthy upgrade
+      ;;
+    *)
+      # Any non-deployed status (pending-*, failed, uninstalling, unknown)
+      # blocks `helm upgrade --install`. Purge the helm storage secrets for
+      # this release so we can install fresh. The underlying PostgresCluster
+      # PVCs are owned by the operator independently and will be rebound.
+      echo "Release in '${HELM_RELEASE_STATUS}' state; purging helm history before reinstall."
+      helm uninstall "$RELEASE_NAME" --wait --timeout 2m 2>/dev/null || true
+      # If helm uninstall couldn't clear it (e.g. release stuck 'uninstalling'),
+      # delete the storage secrets directly. Pattern: sh.helm.release.v1.<name>.v<n>
+      oc delete secret -l "owner=helm,name=${RELEASE_NAME}" --ignore-not-found=true || true
+      # Also clean up the PostgresCluster CR if it still exists; next helm install
+      # may fail with "already exists" if we only purge helm secrets.
+      oc delete postgrescluster.postgres-operator.crunchydata.com/${RELEASE_NAME}-crunchy \
+        --ignore-not-found=true --wait=true 2>/dev/null || true
+      ;;
+  esac
+fi
 
 # Execute the Helm command
 if [ "${DEBUG_MODE:-false}" = "true" ]; then

--- a/scripts/resolve_helm_args.sh
+++ b/scripts/resolve_helm_args.sh
@@ -1,0 +1,119 @@
+#!/bin/bash
+#
+# Pure helper: resolves Helm --set arguments for the crunchy chart from
+# environment variables. Performs validation and emits the assembled string
+# to stdout. Has no side effects (no cd, no helm, no curl), which makes it
+# trivially unit-testable from bats.
+#
+# Inputs (env vars):
+#   VALUES_URL          Non-empty when caller supplied a values_file. When set,
+#                       any sizing/version override env vars trigger a fail-fast
+#                       guardrail (mutually exclusive with file-based config).
+#   PVC_SIZE            Default: 150Mi
+#   STORAGE_CLASS       Default: netapp-block-standard
+#   POSTGRES_VERSION    Default: 18. Must be 15/16/17/18 (operator 5.8.5).
+#   REPLICAS            Default: 2
+#   CPU_REQUEST         Default: 50m
+#   MEMORY_REQUEST      Default: 128Mi
+#   ROUTE_ENABLED       'true' to emit --set route.enabled=true
+#   ROUTE_HOST          Optional route hostname
+#   S3_ACCESS_KEY       All four S3_* vars must be set together to enable
+#   S3_SECRET_KEY       pgBackRest S3 backups.
+#   S3_BUCKET
+#   S3_ENDPOINT
+#
+# Output: assembled SET_STRINGS on stdout; diagnostics on stderr.
+# Exit:   0 on success, 1 on validation failure.
+
+set -euo pipefail
+
+VALUES_URL="${VALUES_URL:-}"
+
+# Conflict check: custom values_file is mutually exclusive with sizing/version
+# overrides because we can't reliably merge a user-authored file with --set
+# flags without surprising precedence behavior.
+if [ -n "${VALUES_URL}" ]; then
+  if [ -n "${PVC_SIZE:-}" ] || [ -n "${STORAGE_CLASS:-}" ] || \
+     [ -n "${POSTGRES_VERSION:-}" ] || [ -n "${REPLICAS:-}" ] || \
+     [ -n "${CPU_REQUEST:-}" ] || [ -n "${MEMORY_REQUEST:-}" ]; then
+    {
+      echo "=========================================================================="
+      echo "CONFIGURATION CONFLICT DETECTED"
+      echo "=========================================================================="
+      echo "You provided a custom 'values_file' (${VALUES_URL}) but also specified"
+      echo "one or more database sizing/resource override inputs:"
+      echo "  - pvc_size: '${PVC_SIZE:-}'"
+      echo "  - storage_class: '${STORAGE_CLASS:-}'"
+      echo "  - postgres_version: '${POSTGRES_VERSION:-}'"
+      echo "  - replicas: '${REPLICAS:-}'"
+      echo "  - cpu_request: '${CPU_REQUEST:-}'"
+      echo "  - memory_request: '${MEMORY_REQUEST:-}'"
+      echo ""
+      echo "Move all sizing/resource settings into your custom values file, OR"
+      echo "drop the values_file input and configure exclusively via workflow inputs."
+      echo "=========================================================================="
+    } >&2
+    exit 1
+  fi
+fi
+
+SET_STRINGS=""
+
+# Sizing/version overrides only apply when no values_file is supplied.
+if [ -z "${VALUES_URL}" ]; then
+  PVC_SIZE="${PVC_SIZE:-150Mi}"
+  STORAGE_CLASS="${STORAGE_CLASS:-netapp-block-standard}"
+  POSTGRES_VERSION="${POSTGRES_VERSION:-18}"
+  REPLICAS="${REPLICAS:-2}"
+  CPU_REQUEST="${CPU_REQUEST:-50m}"
+  MEMORY_REQUEST="${MEMORY_REQUEST:-128Mi}"
+
+  SET_STRINGS+=" --set-string crunchy.instances.dataVolumeClaimSpec.storage=${PVC_SIZE}"
+  SET_STRINGS+=" --set-string crunchy.instances.dataVolumeClaimSpec.storageClassName=${STORAGE_CLASS}"
+  SET_STRINGS+=" --set crunchy.postgresVersion=${POSTGRES_VERSION}"
+
+  # Resolve a known-good (image, postGISVersion) pair for the requested
+  # PostgreSQL major version. Crunchy Operator 5.8.5 only ships defaults for
+  # specific PG/PostGIS combos, so an empty image field is unreliable.
+  case "${POSTGRES_VERSION}" in
+    15) CRUNCHY_IMAGE_TAG="ubi9-15.15-3.3-2547"; CRUNCHY_POSTGIS_VERSION="3.3" ;;
+    16) CRUNCHY_IMAGE_TAG="ubi9-16.11-3.4-2547"; CRUNCHY_POSTGIS_VERSION="3.4" ;;
+    17) CRUNCHY_IMAGE_TAG="ubi9-17.7-3.6-2547";  CRUNCHY_POSTGIS_VERSION="3.6" ;;
+    18) CRUNCHY_IMAGE_TAG="ubi9-18.1-3.6-2547";  CRUNCHY_POSTGIS_VERSION="3.6" ;;
+    *)
+      {
+        echo "Error: Unsupported postgres_version '${POSTGRES_VERSION}'."
+        echo "Supported values (Crunchy Operator 5.8.5): 15, 16, 17, 18."
+        echo "For combinations outside this list, supply a custom values_file"
+        echo "with crunchy.image and crunchy.postGISVersion set explicitly."
+      } >&2
+      exit 1
+      ;;
+  esac
+  SET_STRINGS+=" --set-string crunchy.image=artifacts.developer.gov.bc.ca/bcgov-docker-local/crunchy-postgres-gis:${CRUNCHY_IMAGE_TAG}"
+  SET_STRINGS+=" --set-string crunchy.postGISVersion=${CRUNCHY_POSTGIS_VERSION}"
+
+  SET_STRINGS+=" --set crunchy.instances.replicas=${REPLICAS}"
+  SET_STRINGS+=" --set-string crunchy.instances.requests.cpu=${CPU_REQUEST}"
+  SET_STRINGS+=" --set-string crunchy.instances.requests.memory=${MEMORY_REQUEST}"
+fi
+
+if [ "${ROUTE_ENABLED:-false}" = "true" ]; then
+  SET_STRINGS+=" --set route.enabled=true"
+fi
+
+if [ -n "${ROUTE_HOST:-}" ]; then
+  SET_STRINGS+=" --set-string route.host=${ROUTE_HOST}"
+fi
+
+if [ -n "${S3_ACCESS_KEY:-}" ] && [ -n "${S3_SECRET_KEY:-}" ] && \
+   [ -n "${S3_BUCKET:-}" ] && [ -n "${S3_ENDPOINT:-}" ]; then
+  SET_STRINGS+=" --set crunchy.pgBackRest.s3.enabled=true"
+  SET_STRINGS+=" --set-string crunchy.pgBackRest.s3.accessKey=${S3_ACCESS_KEY}"
+  SET_STRINGS+=" --set-string crunchy.pgBackRest.s3.secretKey=${S3_SECRET_KEY}"
+  SET_STRINGS+=" --set-string crunchy.pgBackRest.s3.bucket=${S3_BUCKET}"
+  SET_STRINGS+=" --set-string crunchy.pgBackRest.s3.endpoint=${S3_ENDPOINT}"
+fi
+
+# Trim leading space for cleaner output
+echo "${SET_STRINGS# }"

--- a/tests/resolve_helm_args.bats
+++ b/tests/resolve_helm_args.bats
@@ -1,0 +1,199 @@
+#!/usr/bin/env bats
+#
+# Unit tests for scripts/resolve_helm_args.sh
+#
+# These run offline in ~seconds and cover the script's full surface:
+#   - sizing defaults
+#   - postgres_version -> (image, postGISVersion) lookup
+#   - unsupported version rejection
+#   - guardrail conflict (values_file + overrides)
+#   - route_enabled toggle behavior
+#   - route_host pass-through
+#   - S3 args (all-or-nothing)
+#
+# Run locally: bats tests/
+
+setup() {
+  SCRIPT="${BATS_TEST_DIRNAME}/../scripts/resolve_helm_args.sh"
+  # Strip every env var the script reads so prior runs don't bleed in.
+  unset VALUES_URL PVC_SIZE STORAGE_CLASS POSTGRES_VERSION REPLICAS \
+        CPU_REQUEST MEMORY_REQUEST ROUTE_ENABLED ROUTE_HOST \
+        S3_ACCESS_KEY S3_SECRET_KEY S3_BUCKET S3_ENDPOINT
+}
+
+# ---- defaults --------------------------------------------------------------
+
+@test "defaults: applies documented values for zero-config" {
+  run "${SCRIPT}"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"storage=150Mi"* ]]
+  [[ "$output" == *"storageClassName=netapp-block-standard"* ]]
+  [[ "$output" == *"crunchy.postgresVersion=18"* ]]
+  [[ "$output" == *"crunchy.instances.replicas=2"* ]]
+  [[ "$output" == *"requests.cpu=50m"* ]]
+  [[ "$output" == *"requests.memory=128Mi"* ]]
+}
+
+@test "defaults: emits PG18 image and GIS 3.6 by default" {
+  run "${SCRIPT}"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"crunchy-postgres-gis:ubi9-18.1-3.6-2547"* ]]
+  [[ "$output" == *"crunchy.postGISVersion=3.6"* ]]
+}
+
+@test "defaults: does not emit route.enabled when unset" {
+  run "${SCRIPT}"
+  [ "$status" -eq 0 ]
+  [[ "$output" != *"route.enabled"* ]]
+}
+
+@test "defaults: does not emit S3 args when unset" {
+  run "${SCRIPT}"
+  [ "$status" -eq 0 ]
+  [[ "$output" != *"pgBackRest.s3"* ]]
+}
+
+# ---- postgres_version lookup ----------------------------------------------
+
+@test "version lookup: PG15 -> ubi9-15.15-3.3-2547, GIS 3.3" {
+  POSTGRES_VERSION=15 run "${SCRIPT}"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"crunchy-postgres-gis:ubi9-15.15-3.3-2547"* ]]
+  [[ "$output" == *"crunchy.postGISVersion=3.3"* ]]
+}
+
+@test "version lookup: PG16 -> ubi9-16.11-3.4-2547, GIS 3.4" {
+  POSTGRES_VERSION=16 run "${SCRIPT}"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"crunchy-postgres-gis:ubi9-16.11-3.4-2547"* ]]
+  [[ "$output" == *"crunchy.postGISVersion=3.4"* ]]
+}
+
+@test "version lookup: PG17 -> ubi9-17.7-3.6-2547, GIS 3.6" {
+  POSTGRES_VERSION=17 run "${SCRIPT}"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"crunchy-postgres-gis:ubi9-17.7-3.6-2547"* ]]
+  [[ "$output" == *"crunchy.postGISVersion=3.6"* ]]
+}
+
+@test "version lookup: PG18 -> ubi9-18.1-3.6-2547, GIS 3.6" {
+  POSTGRES_VERSION=18 run "${SCRIPT}"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"crunchy-postgres-gis:ubi9-18.1-3.6-2547"* ]]
+  [[ "$output" == *"crunchy.postGISVersion=3.6"* ]]
+}
+
+@test "version lookup: unsupported version exits 1" {
+  POSTGRES_VERSION=14 run "${SCRIPT}"
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"Unsupported postgres_version"* ]]
+}
+
+@test "version lookup: garbage version exits 1" {
+  POSTGRES_VERSION=banana run "${SCRIPT}"
+  [ "$status" -eq 1 ]
+}
+
+# ---- sizing overrides ------------------------------------------------------
+
+@test "overrides: custom pvc_size and storage_class propagate" {
+  PVC_SIZE=500Mi STORAGE_CLASS=netapp-file-standard run "${SCRIPT}"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"storage=500Mi"* ]]
+  [[ "$output" == *"storageClassName=netapp-file-standard"* ]]
+}
+
+@test "overrides: custom replicas, cpu, memory propagate" {
+  REPLICAS=3 CPU_REQUEST=100m MEMORY_REQUEST=256Mi run "${SCRIPT}"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"replicas=3"* ]]
+  [[ "$output" == *"requests.cpu=100m"* ]]
+  [[ "$output" == *"requests.memory=256Mi"* ]]
+}
+
+# ---- guardrail -------------------------------------------------------------
+
+@test "guardrail: values_file + pvc_size exits 1" {
+  VALUES_URL=file:///tmp/x.yml PVC_SIZE=200Mi run "${SCRIPT}"
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"CONFIGURATION CONFLICT DETECTED"* ]]
+}
+
+@test "guardrail: values_file + postgres_version exits 1" {
+  VALUES_URL=file:///tmp/x.yml POSTGRES_VERSION=17 run "${SCRIPT}"
+  [ "$status" -eq 1 ]
+}
+
+@test "guardrail: values_file + replicas exits 1" {
+  VALUES_URL=file:///tmp/x.yml REPLICAS=3 run "${SCRIPT}"
+  [ "$status" -eq 1 ]
+}
+
+@test "guardrail: values_file alone is allowed" {
+  VALUES_URL=file:///tmp/x.yml run "${SCRIPT}"
+  [ "$status" -eq 0 ]
+  # No sizing args should be emitted; chart values file owns those.
+  [[ "$output" != *"dataVolumeClaimSpec"* ]]
+  [[ "$output" != *"postgresVersion"* ]]
+}
+
+@test "guardrail: values_file allows route_enabled (route is orthogonal)" {
+  VALUES_URL=file:///tmp/x.yml ROUTE_ENABLED=true run "${SCRIPT}"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"route.enabled=true"* ]]
+}
+
+# ---- route flags -----------------------------------------------------------
+
+@test "route: enabled=true emits --set route.enabled=true" {
+  ROUTE_ENABLED=true run "${SCRIPT}"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"route.enabled=true"* ]]
+}
+
+@test "route: enabled=false emits nothing (chart default is off)" {
+  ROUTE_ENABLED=false run "${SCRIPT}"
+  [ "$status" -eq 0 ]
+  [[ "$output" != *"route.enabled"* ]]
+}
+
+@test "route: host without enabled still propagates host" {
+  # Edge case: if someone passes a host but not enabled=true, we still emit
+  # the host (chart will ignore it). Documents current behavior.
+  ROUTE_HOST=db.example.com run "${SCRIPT}"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"route.host=db.example.com"* ]]
+}
+
+@test "route: enabled + host both propagate" {
+  ROUTE_ENABLED=true ROUTE_HOST=db.example.com run "${SCRIPT}"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"route.enabled=true"* ]]
+  [[ "$output" == *"route.host=db.example.com"* ]]
+}
+
+# ---- S3 (all-or-nothing) ---------------------------------------------------
+
+@test "s3: all four vars set -> emits pgBackRest.s3 args" {
+  S3_ACCESS_KEY=ak S3_SECRET_KEY=sk S3_BUCKET=b S3_ENDPOINT=https://s3 \
+    run "${SCRIPT}"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"pgBackRest.s3.enabled=true"* ]]
+  [[ "$output" == *"pgBackRest.s3.accessKey=ak"* ]]
+  [[ "$output" == *"pgBackRest.s3.secretKey=sk"* ]]
+  [[ "$output" == *"pgBackRest.s3.bucket=b"* ]]
+  [[ "$output" == *"pgBackRest.s3.endpoint=https://s3"* ]]
+}
+
+@test "s3: missing one var -> no s3 args emitted" {
+  S3_ACCESS_KEY=ak S3_SECRET_KEY=sk S3_BUCKET=b run "${SCRIPT}"
+  [ "$status" -eq 0 ]
+  [[ "$output" != *"pgBackRest.s3"* ]]
+}
+
+@test "s3: empty string treated as unset" {
+  S3_ACCESS_KEY="" S3_SECRET_KEY=sk S3_BUCKET=b S3_ENDPOINT=https://s3 \
+    run "${SCRIPT}"
+  [ "$status" -eq 0 ]
+  [[ "$output" != *"pgBackRest.s3"* ]]
+}

--- a/values.yml
+++ b/values.yml
@@ -141,3 +141,7 @@ crunchy: # enable it for TEST and PROD, for PR based pipelines simply use single
       databases:
         - '{{ .Values.global.config.dbName }}'
         - 'postgres'
+
+route:
+  enabled: false
+  host: ~

--- a/values.yml
+++ b/values.yml
@@ -5,8 +5,9 @@ crunchy: # enable it for TEST and PROD, for PR based pipelines simply use single
   enabled: true
   postgresVersion: 18
   postGISVersion: "3.6"
-  imagePullPolicy: IfNotPresent
   image: "artifacts.developer.gov.bc.ca/bcgov-docker-local/crunchy-postgres-gis:ubi9-18.1-3.6-2547"
+  openshift: true
+  imagePullPolicy: IfNotPresent
   # enable below to start a new crunchy cluster after disaster from a backed-up location, crunchy will choose the best place to recover from.
   # follow https://access.crunchydata.com/documentation/postgres-operator/5.8/tutorials/backups-disaster-recovery/disaster-recovery
   # Clone From Backups Stored in S3 / GCS / Azure Blob Storage
@@ -32,9 +33,9 @@ crunchy: # enable it for TEST and PROD, for PR based pipelines simply use single
         prometheus.io/scrape: 'true'
         prometheus.io/port: '9187'
     dataVolumeClaimSpec:
-      storage: 210Mi
+      storage: 150Mi
       storageClassName: netapp-block-standard
-      walStorage: 255Mi
+      walStorage: 300Mi
 
     requests:
       cpu: 50m
@@ -47,7 +48,7 @@ crunchy: # enable it for TEST and PROD, for PR based pipelines simply use single
   pgBackRest:
     enabled: true
     backupPath: /backups/test/cluster/version # change it for PROD, create values-prod.yaml
-    clusterCounter: 2 # this is the number to identify what is the current counter for the cluster, each time it is cloned it should be incremented.
+    clusterCounter: 1 # this is the number to identify what is the current counter for the cluster, each time it is cloned it should be incremented.
     # If retention-full-type set to 'count' then the oldest backups will expire when the number of backups reach the number defined in retention
     # If retention-full-type set to 'time' then the number defined in retention will take that many days worth of full backups before expiration
     retentionFullType: count
@@ -58,13 +59,13 @@ crunchy: # enable it for TEST and PROD, for PR based pipelines simply use single
       endpoint: ~
       accessKey: ~
       secretKey: ~
-      fullBackupSchedule: 0 9 * * *
-      incrementalBackupSchedule: 0 0/5 * * * # every 5 hour incremental
+      fullBackupSchedule: ~
+      incrementalBackupSchedule: ~
     pvc:
       retention: 1 # one day hot active backup in pvc
       retentionFullType: count
       fullBackupSchedule: 0 8 * * *
-      incrementalBackupSchedule: 0 0,12 * * * # every 12 hour incremental
+      incrementalBackupSchedule: 0 0-7,9-23 * * * # every hour incremental
       volume:
         accessModes: "ReadWriteOnce"
         storage: 100Mi
@@ -90,8 +91,8 @@ crunchy: # enable it for TEST and PROD, for PR based pipelines simply use single
   patroni:
     postgresql:
       pg_hba:
-        - "host all all 0.0.0.0/0 md5"
-        - "host all all ::1/128 md5"
+        - "host all all 0.0.0.0/0 scram-sha-256"
+        - "host all all ::1/128 scram-sha-256"
       parameters:
         shared_buffers: 16MB # default is 128MB; a good tuned default for shared_buffers is 25% of the memory allocated to the pod
         wal_buffers: "64kB" # this can be set to -1 to automatically set as 1/32 of shared_buffers or 64kB, whichever is larger
@@ -106,11 +107,12 @@ crunchy: # enable it for TEST and PROD, for PR based pipelines simply use single
     enabled: true
     pgBouncer:
       image: # it's not necessary to specify an image as the images specified in the Crunchy Postgres Operator will be pulled by default
-      replicas: 1
+      replicas: 2
       requests:
         cpu: 5m
         memory: 32Mi
-      maxConnections: 10 # make sure less than postgres max connections
+      maxConnections: 100 # make sure less than postgres max connections
+      poolMode: 'transaction'
 
   # Postgres Cluster resource values:
   pgmonitor:
@@ -120,13 +122,8 @@ crunchy: # enable it for TEST and PROD, for PR based pipelines simply use single
       requests:
         cpu: 10m
         memory: 32Mi
+
   # Custom users section. This section defines database users and their associated configurations.
-  # Each user entry can include the following fields:
-  # - name: The username. Can use template interpolation (e.g., {{ .Values.global.config.dbName }}).
-  # - databases: A list of databases the user has access to. Can include template-interpolated values.
-  # - options: A string specifying user privileges (e.g., "SUPERUSER CREATEDB CREATEROLE"). Ensure the options are valid PostgreSQL roles.
-  # For more details, refer to the Crunchy Postgres Operator documentation: 
-  # https://access.crunchydata.com/documentation/postgres-operator/latest/tutorials/basic-setup/user-management
   users: 
     - name: '{{ .Values.global.config.dbName }}'
       databases:
@@ -144,4 +141,3 @@ crunchy: # enable it for TEST and PROD, for PR based pipelines simply use single
       databases:
         - '{{ .Values.global.config.dbName }}'
         - 'postgres'
-        


### PR DESCRIPTION
## Description

Make `values_file` optional and add override inputs so consumers can deploy Crunchy without authoring a chart values file.

## Changes

- **Optional `values_file`**: when omitted, the action's bundled `values.yml` is used. When provided, the file is copied to `/tmp` before `actions/checkout` wipes the workspace (fixes private-repo token issues).
- **Override inputs** (ignored when `values_file` is set; conflict guardrail enforces mutual exclusion):
  - `pvc_size` (default `150Mi`)
  - `storage_class` (default `netapp-block-standard`)
  - `postgres_version` (default `18`) — see [Supported PostgreSQL Versions](https://github.com/bcgov/action-crunchy/blob/feat/local-values-file/README.md#supported-postgresql-versions)
  - `replicas` (default `2`)
  - `cpu_request` (default `50m`)
  - `memory_request` (default `128Mi`)
  - `route_enabled` (default `false`) + `route_host` — exposes a TLS passthrough OpenShift Route
- **Version -> image lookup** (`scripts/resolve_helm_args.sh`): resolves a known-good Crunchy image + PostGIS version per `postgres_version` (PG 15/16/17/18). Unsupported values fail fast.
- **TLS passthrough Route template** (`charts/crunchy/templates/route.yaml`): optional, gated on `route.enabled`.
- **YAML validation**: local `values_file` is parsed with `yq` (when available) before deploy.
- **`self_heal_stuck_releases` input**: when `true`, purges stuck Helm releases (`uninstalling`, `failed`, etc.) before reinstall. Also cleans up PostgresCluster CR to prevent "already exists" errors. Default `false` to preserve rollback ability.
- **Dead-code removal**: dropped the broken `S3_ENABLED` block in `action.yml` (always-true length check, undefined `s3_vars_count`, unused env var). S3 routing already happens in `deploy_db.sh` based on the four S3 inputs.
- **Route flag noise**: only emit `--set route.enabled=true` when explicitly enabled.

## Refactor

`scripts/resolve_helm_args.sh` extracts all Helm `--set` arg resolution and validation from `deploy_db.sh` into a pure, side-effect-free helper. Sourced by `deploy_db.sh` and exercised directly by unit tests.

## CI test pyramid

Replaces four parallel cluster deploys (which overloaded the shared namespace and mostly tested helm arg rendering) with a layered approach:

- **`validate` job** (offline, ~20s):
  - 24 bats tests against `resolve_helm_args.sh` — defaults, PG15/16/17/18 lookup, unsupported version, guardrail conflict, route toggles, S3 all-or-nothing.
  - `helm lint` on the chart.
  - `helm template` rendering with bundled values (asserts PostgresCluster present, Route absent).
  - `helm template` rendering with PG17 + route overrides (asserts correct image tag, GIS version, storage size, Route + host).
- **`deploy-db` job** (cluster, ~7m): single end-to-end deploy using `values_file` + S3 + computed release name. Gated on `validate` so cluster time isn't wasted on broken changes.

One PostgresCluster per PR, parallel-safe across PRs, most regressions caught in seconds.

Closes #58