### PR TITLE
feat: charts including a route for external db access

### DIFF
--- a/charts/crunchy-with-route/.helmignore
+++ b/charts/crunchy-with-route/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/charts/crunchy-with-route/Chart.yaml
+++ b/charts/crunchy-with-route/Chart.yaml
@@ -1,0 +1,26 @@
+apiVersion: v2
+name: bcgsdi-staging-geochem-crunchy-postgres
+description: Helm chart for deploying Crunchy PostgreSQL cluster with high availability, automated backups to S3, and connection pooling via PgBouncer
+
+# A chart can be either an 'application' or a 'library' chart.
+#
+# Application charts are a collection of templates that can be packaged into versioned archives
+# to be deployed.
+#
+# Library charts provide useful utilities or functions for the chart developer. They're included as
+# a dependency of application charts to inject those utilities and functions into the rendering
+# pipeline. Library charts do not define any templates and therefore cannot be deployed.
+type: application
+
+# This is the chart version. This version number should be incremented each time you make changes
+# to the chart and its templates, including the app version.
+# Versions are expected to follow Semantic Versioning (https://semver.org/)
+version: 0.0.1
+
+# This is the version number of the application being deployed. This version number should be
+# incremented each time you make changes to the application. Versions are not expected to
+# follow Semantic Versioning. They should reflect the version the application is using.
+# It is recommended to use it with quotes.
+
+# Crunchy Postgres Operator version
+appVersion: "5.8.4"

--- a/charts/crunchy-with-route/README.md
+++ b/charts/crunchy-with-route/README.md
@@ -1,0 +1,299 @@
+# Crunchy PostgreSQL Cluster for BCGSDI Staging
+
+This Helm chart deploys a highly available PostgreSQL cluster using the Crunchy PostgreSQL Operator with automated backups, connection pooling, and PostGIS support.
+
+## Features
+
+- **High Availability**: 2 PostgreSQL instances (primary + replica) with automatic failover
+- **Dual Backup Strategy**: 
+  - **repo1**: Local PVC-based backups for fast recovery
+  - **repo2**: S3-based backups for offsite disaster recovery
+- **Connection Pooling**: PgBouncer for improved performance and scalability
+- **PostGIS Support**: Geographic information system extension
+- **Automated Backups**: Scheduled full and incremental backups
+- **Point-in-Time Recovery**: Restore to any point in time from backups
+
+## Backup Configuration
+
+The cluster is configured with two backup repositories:
+
+### Repository 1 (repo1) - PVC Backup
+
+- **Purpose**: Local backup copy stored on persistent volume for fast recovery
+- **Storage**: 10Gi on `netapp-file-backup` storage class
+- **Retention**: 7 full backups (configurable via `pgBackRest.repo1Retention`)
+- **Schedule**:
+  - Full backup: Daily at 8:00 AM UTC (`0 8 * * *`)
+  - Incremental backup: Every 4 hours at 12:00 AM, 4:00 AM, 12:00 PM, 4:00 PM, 8:00 PM UTC (`0 0,4,12,16,20 * * *`)
+
+### Repository 2 (repo2) - S3 Backup
+
+- **Purpose**: Offsite backup for disaster recovery
+- **Storage**: S3-compatible object storage at `nrs.objectstore.gov.bc.ca`
+- **Retention**: 30 full backups (configurable via `pgBackRest.repo2Retention`)
+- **Schedule**:
+  - Full backup: Daily at 9:00 AM UTC (`0 9 * * *`)
+  - Incremental backup: Every 4 hours at 1:00 AM, 5:00 AM, 1:00 PM, 5:00 PM, 9:00 PM UTC (`0 1,5,13,17,21 * * *`)
+
+**Note:** S3 backup schedules are offset by 1 hour from PVC schedules to avoid resource conflicts.
+
+## Verifying PVC Backups
+
+### 1. Check Backup Repository Pod
+
+The PVC backup repository is managed by the `repo-host` pod:
+
+```bash
+# List all pods in the namespace
+kubectl get pods -n <namespace>
+
+# Find the repo-host pod
+kubectl get pods -n <namespace> | grep repo-host
+
+# Example output:
+# bcgsdi-staging-geochem-crunchy-postgres-repo-host-0   2/2     Running   0          1h
+```
+
+### 2. Access the Backup PVC
+
+The backup files are stored in a persistent volume claim (PVC):
+
+```bash
+# List PVCs
+kubectl get pvc -n <namespace>
+
+# Find the backup PVC
+kubectl get pvc -n <namespace> | grep pgbackrest
+
+# Example output:
+# bcgsdi-staging-geochem-crunchy-postgres-repo1   Bound    pvc-xxxxx   10Gi       RWO            netapp-file-backup   1h
+```
+
+### 3. Verify Backup Files Exist
+
+You can exec into the repo-host pod to verify backup files:
+
+```bash
+# Access the repo-host pod
+kubectl exec -it bcgsdi-staging-geochem-crunchy-postgres-repo-host-0 -n <namespace> -c pgbackrest -- bash
+
+# Navigate to the backup repository directory
+cd /pgbackrest/repo1
+
+# List backup files
+ls -lh
+
+# View backup info
+pgbackrest info --stanza=db --repo=1
+
+# Example output:
+# stanza: db
+#     status: ok
+#     cipher: none
+#
+#     db (current)
+#         wal archive min/max (18): 000000010000000000000001/000000010000000000000008
+#
+#         full backup: 20260219-080000F
+#             timestamp start/stop: 2026-02-19 08:00:00 / 2026-02-19 08:05:23
+#             wal start/stop: 000000010000000000000002 / 000000010000000000000002
+#             database size: 25.3MB, database backup size: 25.3MB
+```
+
+### 4. Check Backup Status via PostgresCluster
+
+You can also check the backup status through the PostgresCluster custom resource:
+
+```bash
+# Get backup status
+kubectl describe postgrescluster bcgsdi-staging-geochem-crunchy-postgres -n <namespace>
+
+# Look for the "Pgbackrest" section in the status output
+```
+
+### 5. View Backup Logs
+
+Check the logs of the repo-host pod for backup activity:
+
+```bash
+# View recent logs
+kubectl logs bcgsdi-staging-geochem-crunchy-postgres-repo-host-0 -n <namespace> -c pgbackrest
+
+# Follow logs in real-time
+kubectl logs -f bcgsdi-staging-geochem-crunchy-postgres-repo-host-0 -n <namespace> -c pgbackrest
+```
+
+## Configuration Options
+
+### Persistent Volume Configuration
+
+The PVC backup volume is configured in `values.yaml`:
+
+```yaml
+pgBackRest:
+  repos:
+    volume:
+      accessModes: "ReadWriteOnce"
+      storage: 10Gi
+      storageClassName: netapp-file-backup
+```
+
+**Storage Class**: The `netapp-file-backup` storage class is used for backup volumes. This is a file-based storage suitable for backup repositories that require ReadWriteOnce access.
+
+### Backup Schedule Customization
+
+You can customize backup schedules in `values.yaml`:
+
+**PVC Backups (repo1):**
+```yaml
+pgBackRest:
+  repos:
+    schedules:
+      full: 0 8 * * *  # Daily full backup at 8:00 AM UTC
+      incremental: 0 0,4,12,16,20 * * *  # Incremental every 4 hours
+```
+
+**S3 Backups (repo2):**
+```yaml
+pgBackRest:
+  s3:
+    fullSchedule: "0 9 * * *"  # Daily full backup at 9:00 AM UTC
+    incrementalSchedule: "0 1,5,13,17,21 * * *"  # Incremental every 4 hours
+```
+
+### Retention Policy
+
+Adjust backup retention in `values.yaml`:
+
+```yaml
+pgBackRest:
+  repo1Retention: "7"   # Keep 7 full backups on PVC
+  repo2Retention: "30"  # Keep 30 full backups on S3
+  retentionFullType: count  # 'count' or 'time'
+```
+
+## Disaster Recovery
+
+### Restore from PVC Backup (repo1)
+
+To restore from the local PVC backup:
+
+```yaml
+# In values.yaml
+restoreFromBackup:
+  enabled: true
+  fromRepoName: repo1  # Use PVC backups for faster restore
+  targetDatetime: '2026-02-19 08:00:00-08:00'
+```
+
+**Note:** PVC backups (repo1) provide faster restore times but have limited retention (7 full backups retained).
+
+### Restore from S3 Backup (repo2)
+
+To restore from S3 backup:
+
+```yaml
+# In values.yaml
+restoreFromBackup:
+  enabled: true
+  fromRepoName: repo2  # Use S3 backups for longer retention
+  targetDatetime: '2026-02-19 08:00:00-08:00'
+```
+
+**Note:** S3 backups (repo2) offer longer retention (30 full backups) but may be slower to restore.
+
+### Bootstrap New Cluster from Backup
+
+To create a new cluster from an existing backup:
+
+```yaml
+# In values.yaml
+bootstrapFromBackup:
+  enabled: true
+  fromRepoName: repo2  # Use repo2 for S3 or repo1 for PVC
+  stanza: db
+```
+
+**Backup Source Options:**
+- `repo1`: Bootstrap from PVC backups (faster, 7 full backups available)
+- `repo2`: Bootstrap from S3 backups (recommended - 30 full backups available)
+
+## Infrastructure Requirements
+
+### Persistent Volume Provisioner
+
+The PVC backups require a storage provisioner that supports:
+- **Access Mode**: ReadWriteOnce (RWO)
+- **Storage Class**: `netapp-file-backup` (or another file-based storage class)
+- **Dynamic Provisioning**: The storage class should support dynamic PVC provisioning
+
+### Storage Class Verification
+
+Verify the storage class exists in your cluster:
+
+```bash
+# List available storage classes
+kubectl get storageclass
+
+# Check if netapp-file-backup exists
+kubectl get storageclass netapp-file-backup -o yaml
+```
+
+If the storage class doesn't exist, you'll need to:
+1. Configure a storage provisioner (e.g., NetApp Trident)
+2. Create the storage class with appropriate parameters
+3. Ensure it supports ReadWriteOnce access mode
+
+## Monitoring and Alerts
+
+### Check Backup Job Status
+
+Monitor backup jobs through CronJobs:
+
+```bash
+# List backup CronJobs
+kubectl get cronjobs -n <namespace>
+
+# View CronJob details
+kubectl describe cronjob bcgsdi-staging-geochem-crunchy-postgres-repo1-full-cronjob -n <namespace>
+
+# View recent jobs
+kubectl get jobs -n <namespace> --sort-by=.metadata.creationTimestamp
+```
+
+### Backup Failure Alerts
+
+Monitor for backup failures by checking:
+1. CronJob execution status
+2. Repo-host pod logs
+3. PostgresCluster status conditions
+
+## Troubleshooting
+
+### Backup PVC Not Created
+
+If the backup PVC is not created:
+1. Verify the storage class exists and supports dynamic provisioning
+2. Check the operator logs for errors
+3. Verify RBAC permissions for the operator
+
+### Backup Jobs Not Running
+
+If scheduled backups are not executing:
+1. Check if CronJobs are created: `kubectl get cronjobs -n <namespace>`
+2. Verify the schedule syntax in values.yaml
+3. Check operator logs for errors
+4. Ensure the repo-host pod is running
+
+### Insufficient Storage
+
+If backups fail due to insufficient storage:
+1. Increase `pgBackRest.repos.volume.storage` in values.yaml
+2. The PVC will need to be resized (requires storage class with `allowVolumeExpansion: true`)
+3. Or adjust retention policy to keep fewer backups
+
+## Additional Resources
+
+- [Crunchy PostgreSQL Operator Documentation](https://access.crunchydata.com/documentation/postgres-operator/latest/)
+- [pgBackRest Documentation](https://pgbackrest.org/user-guide.html)
+- [PostgreSQL Backup Best Practices](https://www.postgresql.org/docs/current/backup.html)

--- a/charts/crunchy-with-route/templates/PostgresCluster.yaml
+++ b/charts/crunchy-with-route/templates/PostgresCluster.yaml
@@ -1,0 +1,289 @@
+apiVersion: postgres-operator.crunchydata.com/v1beta1
+kind: PostgresCluster
+metadata:
+  name: {{ template "crunchy-postgres.fullname" . }}
+  labels: {{ include "crunchy-postgres.labels" . | nindent 4 }}
+spec:
+  # Enable OpenShift-specific configurations
+  openshift: {{ .Values.openshift }}
+  metadata:
+    labels: {{ include "crunchy-postgres.labels" . | nindent 6 }}
+  {{ if .Values.crunchyImage }}  
+  image: {{ .Values.crunchyImage }}
+  {{ end }}
+  imagePullPolicy: {{ .Values.imagePullPolicy }}
+  postgresVersion: {{ .Values.postgresVersion }}
+  {{ if .Values.postGISVersion }}
+  postGISVersion: {{ .Values.postGISVersion | quote }}
+  {{ end }}
+
+
+  # Bootstrap a new cluster from an existing backup
+  # Used for disaster recovery or creating a new cluster from backup data
+  {{ if .Values.bootstrapFromBackup.enabled }}
+  dataSource:
+    pgbackrest:
+      configuration:
+        - secret:
+            name: {{ .Values.pgBackRest.s3.secretName }}
+      global:
+        repo2-path: {{ .Values.pgBackRest.s3.path }}
+        repo2-s3-uri-style: {{ .Values.pgBackRest.s3.uriStyle }}
+      repo:
+        name: {{ .Values.bootstrapFromBackup.fromRepoName }}
+        s3:
+          bucket: {{ .Values.pgBackRest.s3.bucket }}
+          endpoint: {{ .Values.pgBackRest.s3.endpoint }}
+          region: {{ .Values.pgBackRest.s3.region }}
+      stanza: {{ .Values.bootstrapFromBackup.stanza }}
+  {{ end }}
+
+
+  # Enable monitoring with pgmonitor exporter
+  # Exports PostgreSQL metrics for Prometheus
+  {{ if .Values.pgmonitor.enabled }}
+  monitoring:
+    pgmonitor:
+      # this stuff is for the "exporter" container in the "postgres-cluster-ha" set of pods
+      exporter:
+        {{ if .Values.pgmonitor.exporter.image}}
+        image: {{ .Values.pgmonitor.exporter.image}}
+        {{ end }}
+        resources:
+          requests:
+            cpu: {{ .Values.pgmonitor.exporter.requests.cpu }}
+            memory: {{ .Values.pgmonitor.exporter.requests.memory }}
+          {{ if .Values.pgmonitor.exporter.limits }}
+          limits:
+            cpu: {{ .Values.pgmonitor.exporter.limits.cpu }}
+            memory: {{ .Values.pgmonitor.exporter.limits.memory }}
+          {{ end }}
+  {{ end }}
+
+  # PostgreSQL instance configuration
+  # Defines the primary and replica instances
+  instances:
+    - name: {{ .Values.instances.name }}
+      replicas: {{ .Values.instances.replicas }}
+      resources:
+        requests:
+          cpu: {{ .Values.instances.requests.cpu }}
+          memory: {{ .Values.instances.requests.memory }}
+        {{ if .Values.instances.limits }}
+        limits:
+          cpu: {{ .Values.instances.limits.cpu }}
+          memory: {{ .Values.instances.limits.memory }}
+        {{ end }}
+      sidecars:
+        # Sidecar for certificate replication between primary and replicas
+        replicaCertCopy:
+          resources:
+            requests:
+              cpu: {{ .Values.instances.replicaCertCopy.requests.cpu }}
+              memory: {{ .Values.instances.replicaCertCopy.requests.memory }}
+            {{ if .Values.instances.replicaCertCopy.limits }}
+            limits:
+              cpu: {{ .Values.instances.replicaCertCopy.limits.cpu }}
+              memory: {{ .Values.instances.replicaCertCopy.limits.memory }}
+            {{ end }}
+      # Persistent volume claim for PostgreSQL data
+      dataVolumeClaimSpec:
+        accessModes:
+          - "ReadWriteOnce"
+        resources:
+          requests:
+            storage: {{ .Values.instances.dataVolumeClaimSpec.storage }}
+        storageClassName: {{ .Values.instances.dataVolumeClaimSpec.storageClassName }}
+      # Anti-affinity rules to spread instances across availability zones
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+            - weight: 1
+              podAffinityTerm:
+                topologyKey: topology.kubernetes.io/zone
+                labelSelector:
+                  matchLabels:
+                    postgres-operator.crunchydata.com/cluster:
+                      {{ template "crunchy-postgres.fullname" . }}
+                    postgres-operator.crunchydata.com/instance-set: {{ .Values.instances.name }}-ha
+  
+  # Database users configuration
+  # Creates the main database user, postgres superuser, and additional users
+  users:
+    - name: {{ .Values.dbName }}
+      databases:
+        - {{ .Values.dbName }}
+      options: "CREATEROLE"
+    # Postgres superuser with access to the main database
+    - name: postgres
+      databases:
+        - {{ .Values.dbName }}
+    # Additional users from values.yaml
+    {{- range .Values.users }}
+    - name: {{ .name }}
+      databases:
+        - {{ $.Values.dbName }}
+      options: {{ .options | default "CREATEROLE" }}
+    {{- end }}
+ 
+  # Backup configuration using pgBackRest
+  # Supports both PVC (repo1) and S3 (repo2) backup repositories
+  backups:
+    pgbackrest:
+      {{ if .Values.pgBackRest.image }}
+      image: {{ .Values.pgBackRest.image }}
+      {{ end }}
+      configuration:
+      - secret:
+          name: {{ .Values.pgBackRest.s3.secretName }}
+      global:
+        {{- if .Values.pgBackRest.pvc.enabled }}
+        # PVC backup retention (repo1)
+        repo1-retention-full: {{ .Values.pgBackRest.repo1Retention | quote }}
+        repo1-retention-full-type: {{ .Values.pgBackRest.retentionFullType }}
+        {{- end }}
+        {{- if .Values.pgBackRest.s3.enabled }}
+        # S3 backup retention (repo2)
+        repo2-retention-full: {{ .Values.pgBackRest.repo2Retention | quote }}
+        repo2-retention-full-type: {{ .Values.pgBackRest.retentionFullType }}
+        repo2-retention-archive: {{ .Values.pgBackRest.repo2Retention | quote }}
+        repo2-retention-archive-type: full
+        repo2-path: {{ .Values.pgBackRest.s3.path }}
+        repo2-s3-uri-style: {{ .Values.pgBackRest.s3.uriStyle }}
+        {{- end }}
+      # Manual backup configuration 
+      # These settings will be used anytime a manual backup is triggered.
+      manual:
+        repoName: repo2
+        options:
+          - --type=full
+      repos:
+        # PVC-based backup repository (repo1)
+        # Local backup copy stored on persistent volume
+        {{- if .Values.pgBackRest.pvc.enabled }}
+        - name: repo1
+          schedules:
+            full: {{ .Values.pgBackRest.pvc.schedules.full }}
+            incremental: {{ .Values.pgBackRest.pvc.schedules.incremental }}
+          volume:
+            volumeClaimSpec:
+              accessModes:
+                - {{ .Values.pgBackRest.pvc.volume.accessModes }}
+              resources:
+                requests:
+                  storage: {{ .Values.pgBackRest.pvc.volume.storage }}
+              storageClassName: {{ .Values.pgBackRest.pvc.volume.storageClassName }}
+        {{- end }}  
+        {{- if .Values.pgBackRest.s3.enabled }}
+        # S3-based backup repository (repo2)
+        - name: repo2
+          schedules:
+            full: {{ .Values.pgBackRest.s3.fullSchedule }}
+            incremental: {{ .Values.pgBackRest.s3.incrementalSchedule }}
+          s3:
+            bucket: {{ .Values.pgBackRest.s3.bucket }}
+            endpoint: {{ .Values.pgBackRest.s3.endpoint }}
+            region: {{ .Values.pgBackRest.s3.region }}
+        {{- end }}      
+      # Restore from backup configuration
+      # Enable this to restore an existing cluster from a previous backup
+      {{- if .Values.restoreFromBackup.enabled }}   
+      restore:
+        enabled: {{ .Values.restoreFromBackup.enabled }}
+        repoName: {{ .Values.restoreFromBackup.fromRepoName }}
+        options:          
+          - --type=time
+          - --target="{{ .Values.restoreFromBackup.targetTime }}"         
+      {{- end }}
+      # Resource configuration for the repo host pod
+      repoHost:
+        resources:
+          requests:
+            cpu: {{ .Values.pgBackRest.repoHost.requests.cpu }}
+            memory: {{ .Values.pgBackRest.repoHost.requests.memory }}
+          {{- if .Values.pgBackRest.repoHost.limits }}
+          limits:
+            cpu: {{ .Values.pgBackRest.repoHost.limits.cpu }}
+            memory: {{ .Values.pgBackRest.repoHost.limits.memory }}
+          {{- end }}
+      # Resource configuration for backup sidecars in instance pods
+      sidecars:
+        # pgBackRest sidecar in PostgreSQL instance pods
+        pgbackrest:
+          resources:
+            requests:
+              cpu: {{ .Values.pgBackRest.sidecars.requests.cpu }}
+              memory: {{ .Values.pgBackRest.sidecars.requests.memory }}
+            {{- if .Values.pgBackRest.sidecars.limits }}
+            limits:
+              cpu: {{ .Values.pgBackRest.sidecars.limits.cpu }}
+              memory: {{ .Values.pgBackRest.sidecars.limits.memory }}
+            {{- end }}
+        # pgBackRest config sidecar in PostgreSQL instance pods
+        pgbackrestConfig:
+          resources:
+            requests:
+              cpu: {{ .Values.pgBackRest.sidecars.requests.cpu }}
+              memory: {{ .Values.pgBackRest.sidecars.requests.memory }}
+            {{- if .Values.pgBackRest.sidecars.limits }}
+            limits:
+              cpu: {{ .Values.pgBackRest.sidecars.limits.cpu }}
+              memory: {{ .Values.pgBackRest.sidecars.limits.memory }}
+            {{- end }}
+  
+  # Standby cluster configuration
+  # Enable to create a read-only standby cluster that replicates from another cluster
+  standby:
+    enabled: {{ .Values.standby.enabled }}
+    repoName: {{ .Values.standby.repoName }}
+  
+  # Patroni configuration for high availability
+  # Controls PostgreSQL server parameters and connection settings
+  patroni:
+    dynamicConfiguration:
+      postgresql:
+        # Host-based authentication configuration
+        pg_hba:
+          - {{ .Values.patroni.postgresql.pg_hba}}
+        # PostgreSQL server parameters for performance tuning
+        parameters:
+          shared_buffers: {{ .Values.patroni.postgresql.parameters.shared_buffers }}
+          wal_buffers: {{ .Values.patroni.postgresql.parameters.wal_buffers }}
+          min_wal_size: {{ .Values.patroni.postgresql.parameters.min_wal_size }}
+          max_wal_size: {{ .Values.patroni.postgresql.parameters.max_wal_size }}
+          max_slot_wal_keep_size:  {{ .Values.patroni.postgresql.parameters.max_slot_wal_keep_size }}
+  
+  # PgBouncer connection pooler configuration
+  # Provides connection pooling for improved performance and scalability
+  proxy:
+    pgBouncer:
+      config:
+        global:
+          # Disable TLS for client connections (adjust based on security requirements)
+          client_tls_sslmode: disable
+      {{ if .Values.proxy.pgBouncer.image }}
+      image: {{ .Values.proxy.pgBouncer.image }}
+      {{ end }}
+      replicas: {{ .Values.proxy.pgBouncer.replicas }}
+      # Resource configuration for pgBouncer pods
+      resources:
+        requests:
+          cpu: {{ .Values.proxy.pgBouncer.requests.cpu }}
+          memory: {{ .Values.proxy.pgBouncer.requests.memory }}
+        {{ if .Values.proxy.pgBouncer.limits }}
+        limits:
+          cpu: {{ .Values.proxy.pgBouncer.limits.cpu }}
+          memory: {{ .Values.proxy.pgBouncer.limits.memory }}
+        {{ end }}
+      # Anti-affinity rules to spread pgBouncer pods across availability zones
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+            - weight: 1
+              podAffinityTerm:
+                topologyKey: topology.kubernetes.io/zone
+                labelSelector:
+                  matchLabels:
+                    postgres-operator.crunchydata.com/cluster:
+                      {{ template "crunchy-postgres.fullname" . }}
+                    postgres-operator.crunchydata.com/role: pgbouncer

--- a/charts/crunchy-with-route/templates/_helpers.tpl
+++ b/charts/crunchy-with-route/templates/_helpers.tpl
@@ -1,0 +1,75 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "crunchy-postgres.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "crunchy-postgres.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "crunchy-postgres.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "crunchy-postgres.labels" -}}
+helm.sh/chart: {{ include "crunchy-postgres.chart" . }}
+{{ include "crunchy-postgres.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "crunchy-postgres.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "crunchy-postgres.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Generate S3 configuration for pgBackRest secret
+This template creates the S3 configuration section used in the pgBackRest secret.
+The S3 credentials (accessKeyId and accessKeySecret) are passed via --set during deployment.
+Supports the following S3 configuration options:
+- accessKeyId: S3 access key ID
+- accessKeySecret: S3 secret access key
+- encryptionPassphrase: Optional encryption passphrase for backups
+*/}}
+{{- define "crunchy.s3" }}
+[global]
+{{- if .s3 }}
+  {{- if .s3.accessKeyId }}
+repo{{ add .index 1 }}-s3-key={{ .s3.accessKeyId }}
+  {{- end }}
+  {{- if .s3.accessKeySecret }}
+repo{{ add .index 1 }}-s3-key-secret={{ .s3.accessKeySecret }}
+  {{- end }}
+  {{- if .s3.encryptionPassphrase }}
+repo{{ add .index 1 }}-cipher-pass={{ .s3.encryptionPassphrase }}
+  {{- end }}
+{{- end }}
+{{ end }}

--- a/charts/crunchy-with-route/templates/route.yaml
+++ b/charts/crunchy-with-route/templates/route.yaml
@@ -1,0 +1,28 @@
+{{/*
+OpenShift Route for external database access.
+This creates a TLS passthrough route to the primary PostgreSQL service,
+allowing external clients to connect to the database over TLS.
+Clients must connect with SSL enabled (e.g., sslmode=require in the connection string).
+*/}}
+{{- if .Values.route.enabled }}
+apiVersion: route.openshift.io/v1
+kind: Route
+metadata:
+  name: {{ template "crunchy-postgres.fullname" . }}
+  labels: {{ include "crunchy-postgres.labels" . | nindent 4 }}
+spec:
+  {{- if .Values.route.host }}
+  host: {{ .Values.route.host }}
+  {{- end }}
+  port:
+    targetPort: postgres
+  tls:
+    termination: passthrough
+    # None: HTTP connections are not accepted; only TLS connections are routed.
+    # Clients must connect using SSL (e.g., sslmode=require in the connection string).
+    insecureEdgeTerminationPolicy: None
+  to:
+    kind: Service
+    name: {{ template "crunchy-postgres.fullname" . }}-primary
+    weight: 100
+{{- end }}

--- a/charts/crunchy-with-route/templates/secret.yaml
+++ b/charts/crunchy-with-route/templates/secret.yaml
@@ -1,0 +1,16 @@
+{{/*
+Secret for S3 backup credentials
+This secret is created when S3 backups are enabled and stores the S3 access credentials.
+The actual credentials (accessKeyId and accessKeySecret) are passed via --set during deployment.
+*/}}
+{{- if and .Values.pgBackRest.s3.enabled .Values.pgBackRest.s3.createS3Secret }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ .Values.pgBackRest.s3.secretName }}
+type: Opaque
+data:
+  {{- $args := dict "s3" .Values.pgBackRest.s3 "index" 1 }}
+  s3.conf: |-
+        {{ include "crunchy.s3" $args | b64enc }}
+{{- end }}

--- a/charts/crunchy-with-route/values.yaml
+++ b/charts/crunchy-with-route/values.yaml
@@ -1,0 +1,176 @@
+# Crunchy PostgreSQL Cluster Configuration
+# This values file configures a highly available PostgreSQL cluster with:
+# - High availability with 2 replicas
+# - Automated backups to both PVC (repo1) and S3 (repo2)
+# - Connection pooling via PgBouncer
+# - PostGIS extension support
+
+fullnameOverride: bcgsdi-staging-geochem-crunchy
+dbName: bcgsdi-staging-geochem
+
+# Optional: Override the default Crunchy Postgres image
+# Leave empty to use the operator's default images
+crunchyImage: # it's not necessary to specify an image as the images specified in the Crunchy Postgres Operator will be pulled by default
+
+# PostgreSQL version and PostGIS extension version
+postgresVersion: 17
+postGISVersion: '3.4'
+imagePullPolicy: IfNotPresent
+
+# Enable OpenShift-specific configurations (security context constraints)
+openshift: true
+
+# Standby cluster configuration
+# Enable to bootstrap a standby (read-only) cluster from an existing cluster's backup
+# After bootstrapping, disable to promote the standby to a primary cluster
+standby:
+  enabled: false
+  # Repository to use for standby replication (repo1=PVC, repo2=S3)
+  repoName: repo2
+
+# PostgreSQL instance configuration
+instances:
+  name: ha # high availability
+  replicas: 2  # Number of PostgreSQL instances (primary + replicas)
+  dataVolumeClaimSpec:
+    storage: 300Mi
+    storageClassName: netapp-block-standard
+  # Resource requests for PostgreSQL containers
+  requests:
+    cpu: 1m
+    memory: 256Mi
+  # Sidecar container for replicating certificates between instances
+  replicaCertCopy:
+    requests:
+      cpu: 1m
+      memory: 32Mi
+
+# Bootstrap from backup configuration
+# When creating a NEW cluster, enable this to initialize it with data from an existing backup
+# This is useful for disaster recovery scenarios where the cluster needs to be recreated
+# For restoring data to an EXISTING cluster, use "restoreFromBackup" section instead
+bootstrapFromBackup:
+  enabled: false
+  fromRepoName: repo2  # Repository containing the backup (repo1=PVC, repo2=S3)
+  stanza: db
+
+# Restore from backup configuration
+# Use this to restore data into an EXISTING cluster from a previous backup
+# When enabled, the PostgresCluster will execute "pgbackrest restore" command
+# For creating a NEW cluster from backup, use "bootstrapFromBackup" section instead
+restoreFromBackup:
+  enabled: false
+  # Restore to a database at the given time (specify in format '2021-06-09 14:15:11-08').
+  # pgbackrest is finicky about the time specified.  It cannot be just any time, even 
+  # if regular backups have been captured by a scheduled process.  Best approach to 
+  # choose a targetTime is:
+  # 1. download backup.info from S3. 
+  # 2. Choose a backup listed in backup.info.  Note the "backup-archive-start" and 
+  # "backup-archive-stop" values.  These identify the write-ahead-logs (WALs) associated 
+  # with the backup.  Also note the "db-id".
+  # 3. From S3 download the [WAL].backup file corresponding to the stop WAL.  
+  # Open the [WALL].backup  file and note the backup STOP TIME. Copy that value here, except replacing UTC with +00.
+  targetTime: 2026-03-04 01:16:19+00 
+  fromRepoName: repo2 
+
+# pgBackRest backup configuration
+# Manages automated backups to both PVC (repo1) and S3 (repo2)
+pgBackRest:
+  image: # it's not necessary to specify an image as the images specified in the Crunchy Postgres Operator will be pulled by default
+  
+  # Backup retention policies
+  repo1Retention: "0"   # Keep 7 full backups on PVC
+  repo2Retention: "30"  # Keep 30 full backups on S3
+  
+  # Retention type: 'count' (number of backups) or 'time' (days to keep)
+  retentionFullType: count
+   
+  # Resource allocation for backup repository host
+  repoHost:
+    requests:
+      cpu: 10m
+      memory: 64Mi
+  
+  # Resource allocation for backup sidecars in PostgreSQL pods
+  sidecars:
+    requests:
+      cpu: 10m
+      memory: 64Mi
+  
+  # PVC backup configuration (repo1)  
+  pvc:
+    enabled: false
+    schedules:
+      full: 0 8 * * *  # Daily full backup at 8:00 AM
+      incremental: 0 0,4,12,16,20 * * *  # Incremental backups every 4 hours
+    volume:
+      accessModes: "ReadWriteOnce"
+      storage: 14Gi
+      storageClassName: netapp-file-standard    
+
+  # S3 backup configuration (repo2)
+  s3:
+    enabled: true
+    createS3Secret: true  # Automatically create the S3 credentials secret
+    secretName: s3-pgbackrest  # Name of the secret containing S3 credentials
+    path: /  # Path within the S3 bucket (must start with /)
+    uriStyle: path  # S3 URI style: 'host' or 'path'
+    bucket: ~  # S3 bucket name (set via --set during deployment)
+    endpoint: "nrs.objectstore.gov.bc.ca"  # S3 endpoint URL
+    region: "ca-central-1"  # S3 region
+    
+    # S3-specific backup schedules (offset by 1 hour from PVC schedules to avoid conflicts)
+    fullSchedule: "0 9 * * *"  # Daily full backup to S3 at 9:00 AM
+    incrementalSchedule: "0 1,5,13,17,21 * * *"  # Incremental backups to S3
+
+# Patroni configuration for PostgreSQL high availability
+patroni:
+  postgresql:
+    # Host-based authentication rules
+    pg_hba: "host all all 0.0.0.0/0 md5"
+    # PostgreSQL server parameters for performance tuning
+    parameters:
+      # Recommended: 25% of allocated memory for optimal performance
+      shared_buffers: 64MB # default is 128MB
+      # Set to -1 for automatic sizing (1/32 of shared_buffers or 64kB, whichever is larger)
+      wal_buffers: -1
+      min_wal_size: 32MB
+      max_wal_size: 128MB # default is 1GB
+      # Limit WAL retention to prevent disk space issues when replicas fall behind
+      max_slot_wal_keep_size: 512MB # default is -1, allowing unlimited wal growth
+
+# PgBouncer connection pooler configuration
+proxy:
+  pgBouncer:
+    image: # it's not necessary to specify an image as the images specified in the Crunchy Postgres Operator will be pulled by default
+    replicas: 2  # Number of PgBouncer instances for high availability
+    requests:
+      cpu: 1m
+      memory: 64Mi
+
+# Monitoring configuration using pgMonitor
+# Disabled by default - enable to export PostgreSQL metrics for Prometheus
+pgmonitor:
+  enabled: false
+  exporter:
+    image: # it's not necessary to specify an image as the images specified in the Crunchy Postgres Operator will be pulled by default
+    requests:
+      cpu: 1m
+      memory: 64Mi
+
+# External access route configuration
+# Creates an OpenShift Route for external database access to the primary PostgreSQL service.
+# Uses TLS passthrough termination - clients must connect with SSL enabled
+# (e.g., add '?sslmode=require' to the connection string).
+# An external route must have host name. If none is provided below, OpenShift will generate
+# a default hostname.  Alternatively, provide a hostname like:
+# bcgsdi-staging-geochem-crunchy-postgres-<namespace>.apps.<cluster>.devops.gov.bc.ca
+route:
+  enabled: true
+  host: 
+
+# Additional database users
+# The main database user (dbName) and postgres superuser are created automatically
+# Add additional users here as needed
+#users:
+#  - name: ycui


### PR DESCRIPTION
This isn't a real pull request.  It's just a way to share some example crunchy charts to provide inspiration for this feature request: https://github.com/bcgov/action-crunchy/issues/61.  

Our team has a requirement to deploy a crunchy database cluster in OpenShift along with a **route** to allow users to connect to the database from their workstations (e.g.  using the psql command line tool from a windows PC).  Currently we don't use action-crunchy for our deployment because it doesn't supply the route.  Instead we have charts that mostly do what action-crunchy does, plus also adds a route.  If action-crunchy could create routes, we wouldn't need to veer outside the common code with our custom scripts.

In our case, our database does not support a web application, so there's no frontend and backend.  We simply have a need to run a database somewhere so that it can be accessed directly by various human users to perform some data preparation tasks.

The route in this example allows users to connect remotely via psql with a command like this:
`psql "postgresql://USERNAME@ROUTE_HOST:443/DB_NAME?sslmode=require&sslnegotiation=direct"`