### PR TITLE
fix(ci): catch results false positive

### DIFF
--- a/.github/workflows/pr-open.yml
+++ b/.github/workflows/pr-open.yml
@@ -63,11 +63,28 @@ jobs:
       - if: contains(steps.deploy_db.outputs.* , '')
         run: |
           echo "Error! At least one output is empty. Verify outputs." && exit 1
+  # ==========================================================================
+  # WARNING: This job acts as the required merge gate for this workflow.
+  # If you add a new job to this workflow, you MUST add its ID to the 'needs'
+  # array below, otherwise its failure or cancellation will not block the PR!
+  # ==========================================================================
   results:
-    if: always()
     name: Results
     needs: [deploy-db-computed, deploy-db-manual]
+    if: always()
     runs-on: ubuntu-24.04
+    timeout-minutes: 1
     steps:
-      - if: contains(needs.*.result, 'failure')||contains(needs.*.result, 'cancelled')
-        run: echo "At least one job has failed or was cancelled." && exit 1
+      - name: Log Job Results Context
+        run: |
+          echo "=== Upstream Job Statuses ==="
+          echo '${{ toJson(needs) }}'
+
+      - name: Evaluate Overall Status
+        if: contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled')
+        run: |
+          echo "❌ Critical Check Failure: At least one required job has failed or was cancelled."
+          exit 1
+
+      - name: Success Message
+        run: echo "✅ All critical checks passed or were intentionally skipped!"

--- a/.github/workflows/pr-open.yml
+++ b/.github/workflows/pr-open.yml
@@ -64,9 +64,10 @@ jobs:
         run: |
           echo "Error! At least one output is empty. Verify outputs." && exit 1
   results:
+    if: always()
     name: Results
     needs: [deploy-db-computed, deploy-db-manual]
     runs-on: ubuntu-24.04
     steps:
       - if: contains(needs.*.result, 'failure')||contains(needs.*.result, 'cancelled')
-        run: echo "At least one job has failed." && exit 1
+        run: echo "At least one job has failed or was cancelled." && exit 1

--- a/.github/workflows/pr-open.yml
+++ b/.github/workflows/pr-open.yml
@@ -68,5 +68,5 @@ jobs:
     needs: [deploy-db-computed, deploy-db-manual]
     runs-on: ubuntu-24.04
     steps:
-      - if: contains(needs.*.result, 'failure')||contains(needs.*.result, 'canceled')
+      - if: contains(needs.*.result, 'failure')||contains(needs.*.result, 'cancelled')
         run: echo "At least one job has failed." && exit 1


### PR DESCRIPTION
This PR corrects the spelling of 'cancelled' (with two 'l's) in GitHub Actions status check and log messages. This prevents false positive passes when job statuses are checked.